### PR TITLE
Rename package

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
-name = "MoistThermodynamics"
-uuid = "0460cc1c-04d8-4f02-b57d-511136c80085"
+name = "Thermodynamics"
+uuid = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MoistThermodynamics.jl
+# Thermodynamics.jl
 A package containing a library of moist thermodynamic relations
 
 |||
@@ -9,17 +9,17 @@ A package containing a library of moist thermodynamic relations
 | **Code Coverage**    | [![codecov][codecov-img]][codecov-url]        |
 | **Bors**             | [![Bors enabled][bors-img]][bors-url]         |
 
-[docs-bld-img]: https://github.com/CliMA/MoistThermodynamics.jl/workflows/Documentation/badge.svg
-[docs-bld-url]: https://github.com/CliMA/MoistThermodynamics.jl/actions?query=workflow%3ADocumentation
+[docs-bld-img]: https://github.com/CliMA/Thermodynamics.jl/workflows/Documentation/badge.svg
+[docs-bld-url]: https://github.com/CliMA/Thermodynamics.jl/actions?query=workflow%3ADocumentation
 
 [docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
-[docs-dev-url]: https://CliMA.github.io/MoistThermodynamics.jl/dev/
+[docs-dev-url]: https://CliMA.github.io/Thermodynamics.jl/dev/
 
-[azure-img]: https://dev.azure.com/climate-machine/MoistThermodynamics.jl/_apis/build/status/climate-machine.MoistThermodynamics.jl?branchName=master
-[azure-url]: https://dev.azure.com/climate-machine/MoistThermodynamics.jl/_build/latest?definitionId=1&branchName=master
+[azure-img]: https://dev.azure.com/climate-machine/Thermodynamics.jl/_apis/build/status/climate-machine.Thermodynamics.jl?branchName=master
+[azure-url]: https://dev.azure.com/climate-machine/Thermodynamics.jl/_build/latest?definitionId=1&branchName=master
 
-[codecov-img]: https://codecov.io/gh/CliMA/MoistThermodynamics.jl/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/CliMA/MoistThermodynamics.jl
+[codecov-img]: https://codecov.io/gh/CliMA/Thermodynamics.jl/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/CliMA/Thermodynamics.jl
 
 [bors-img]: https://bors.tech/images/badge_small.svg
 [bors-url]: https://app.bors.tech/repositories/24783

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,5 @@
 status = [
-  "CliMA.MoistThermodynamics.jl",
+  "CliMA.Thermodynamics.jl",
   "docs-build"
 ]
 delete_merged_branches = true

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,14 +1,16 @@
 
-rm(joinpath(@__DIR__, "Manifest.toml"), force = true) # Remove local Manifest
+rm(joinpath(@__DIR__, "Manifest.toml"), force = true)       # Remove local Manifest.toml
+rm(joinpath(@__DIR__, "..", "Manifest.toml"), force = true) # Remove local Manifest.toml
 
 push!(LOAD_PATH, joinpath(@__DIR__, "..", "env", "Plots")) # add Plots env
-push!(LOAD_PATH, joinpath(@__DIR__, ".."))                 # add MoistThermodynamics env
+
+# Avoiding having to add Thermodynamics deps to docs/ environment:
+push!(LOAD_PATH, joinpath(@__DIR__, ".."))                 # add Thermodynamics env
 
 using Pkg
-Pkg.activate(@__DIR__)
-Pkg.instantiate(; verbose = true)
+Pkg.develop(PackageSpec(path=joinpath(@__DIR__, "..")))
 
-using MoistThermodynamics, Documenter
+using Thermodynamics, Documenter
 
 pages = Any[
     "Home" => "index.md",
@@ -32,15 +34,15 @@ format = Documenter.HTML(
 )
 
 makedocs(
-    sitename = "MoistThermodynamics.jl",
+    sitename = "Thermodynamics.jl",
     format = format,
     clean = true,
-    modules = [Documenter, MoistThermodynamics],
+    modules = [Documenter, Thermodynamics],
     pages = pages,
 )
 
 deploydocs(
-    repo = "github.com/CliMA/MoistThermodynamics.jl.git",
+    repo = "github.com/CliMA/Thermodynamics.jl.git",
     target = "build",
     push_preview = true,
 )

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -1,7 +1,7 @@
 # API
 
 ```@meta
-CurrentModule = MoistThermodynamics
+CurrentModule = Thermodynamics
 ```
 
 ## Thermodynamic State Constructors

--- a/docs/src/HowToGuide.md
+++ b/docs/src/HowToGuide.md
@@ -57,7 +57,7 @@ p = air_pressure(ts);
 
 ## Extending
 
-If MoistThermodynamics.jl does not have a particular thermodynamic constructor that is needed, one can implement a new one in `MoistThermodynamics/src/states.jl`. In this constructor, one must add whichever arguments they wish to offer as inputs, then translate this thermodynamic state into one of:
+If Thermodynamics.jl does not have a particular thermodynamic constructor that is needed, one can implement a new one in `Thermodynamics/src/states.jl`. In this constructor, one must add whichever arguments they wish to offer as inputs, then translate this thermodynamic state into one of:
 
  - `PhaseDry` a dry thermodynamic state, uniquely determined by two independent thermodynamic properties
  - `PhaseEquil` a moist thermodynamic state in thermodynamic equilibrium, uniquely determined by three independent thermodynamic properties

--- a/docs/src/Installation.md
+++ b/docs/src/Installation.md
@@ -1,7 +1,7 @@
 # Installation
 
-MoistThermodynamics.jl is a Julia registered package, and can be added from the Julia Pkg manager:
+Thermodynamics.jl is a Julia registered package, and can be added from the Julia Pkg manager:
 
 ```julia
-(v1.x) pkg> add MoistThermodynamics
+(v1.x) pkg> add Thermodynamics
 ```

--- a/docs/src/TestedProfiles.md
+++ b/docs/src/TestedProfiles.md
@@ -1,12 +1,12 @@
 # Tested Profiles
 
-MoistThermodynamics.jl is tested using a set of profiles, or thermodynamic state regimes, specified in [`tested_profiles`](@ref MoistThermodynamics.tested_profiles).
+Thermodynamics.jl is tested using a set of profiles, or thermodynamic state regimes, specified in [`tested_profiles`](@ref Thermodynamics.tested_profiles).
 
 ## Dry Phase
 
 ```@example
-using MoistThermodynamics
-MT = MoistThermodynamics
+using Thermodynamics
+MT = Thermodynamics
 using CLIMAParameters
 using CLIMAParameters.Planet
 using Plots
@@ -30,8 +30,8 @@ savefig("tested_profiles_dry.svg");
 
 Here is a 2D representation:
 ```@example
-using MoistThermodynamics
-MT = MoistThermodynamics
+using Thermodynamics
+MT = Thermodynamics
 using CLIMAParameters
 using CLIMAParameters.Planet
 using Plots
@@ -48,8 +48,8 @@ savefig("tested_profiles.svg")
 
 And here is a 3D representation:
 ```@example
-using MoistThermodynamics
-MT = MoistThermodynamics
+using Thermodynamics
+MT = Thermodynamics
 using CLIMAParameters
 using CLIMAParameters.Planet
 using Plots

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
-# MoistThermodynamics
+# Thermodynamics
 
-MoistThermodynamics.jl provides all thermodynamic functions needed for the atmosphere and functions shared across model components. The functions are general for a moist atmosphere that includes suspended cloud condensate in the working fluid; the special case of a dry atmosphere is obtained for zero specific humidities (or simply by omitting the optional specific humidity arguments in the functions that are needed for a dry atmosphere). The general formulation assumes that there are tracers for specific humidity `q`, partitioned into
+Thermodynamics.jl provides all thermodynamic functions needed for the atmosphere and functions shared across model components. The functions are general for a moist atmosphere that includes suspended cloud condensate in the working fluid; the special case of a dry atmosphere is obtained for zero specific humidities (or simply by omitting the optional specific humidity arguments in the functions that are needed for a dry atmosphere). The general formulation assumes that there are tracers for specific humidity `q`, partitioned into
 
  - `q.tot` total water specific humidity
  - `q.liq` liquid specific humidity

--- a/src/Thermodynamics.jl
+++ b/src/Thermodynamics.jl
@@ -1,7 +1,7 @@
 """
-    MoistThermodynamics
+    Thermodynamics
 
-Moist thermodynamic functions, e.g., for air pressure (atmosphere equation
+Thermodynamic functions, e.g., for air pressure (atmosphere equation
 of state), latent heats of phase transitions, saturation vapor pressures, and
 saturation specific humidities.
 
@@ -21,9 +21,9 @@ _molmass_ratio = molmass_ratio(param_set)
 ```
 
 Because these parameters are widely used throughout this module,
-`param_set` is an argument for many MoistThermodynamics functions.
+`param_set` is an argument for many Thermodynamics functions.
 """
-module MoistThermodynamics
+module Thermodynamics
 
 using DocStringExtensions
 using RootSolvers

--- a/src/isentropic.jl
+++ b/src/isentropic.jl
@@ -18,7 +18,7 @@ struct DryAdiabaticProcess end
 
 The air pressure for an isentropic process, where
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `θ` potential temperature
  - `Φ` gravitational potential
 """
@@ -39,7 +39,7 @@ end
 
 The air pressure for an isentropic process, where
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
  - `T∞` ambient temperature
  - `p∞` ambient pressure
@@ -60,7 +60,7 @@ end
 
 The air temperature for an isentropic process, where
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `p` pressure
  - `θ` potential temperature
 """

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -34,7 +34,7 @@ end
     tested_profiles(param_set::APS, n::Int, ::Type{FT}) where {FT}
 
 A range of input arguments to thermodynamic state constructors
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `e_int` internal energy
  - `ρ` (moist-)air density
  - `q_tot` total specific humidity

--- a/src/relations.jl
+++ b/src/relations.jl
@@ -38,7 +38,7 @@ export vapor_specific_humidity
     gas_constant_air(param_set, [q::PhasePartition])
 
 The specific gas constant of moist air given
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `q` [`PhasePartition`](@ref). Without this argument, the results are for dry air.
 """
 function gas_constant_air(param_set::APS, q::PhasePartition{FT}) where {FT}
@@ -76,7 +76,7 @@ vapor_specific_humidity(ts::ThermodynamicState) =
 The air pressure from the equation of state
 (ideal gas law) where
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` air temperature
  - `ρ` (moist-)air density
 and, optionally,
@@ -111,7 +111,7 @@ air_pressure(ts::ThermodynamicState) = air_pressure(
 The (moist-)air density from the equation of state
 (ideal gas law) where
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` air temperature
  - `p` pressure
 and, optionally,
@@ -154,7 +154,7 @@ total_specific_humidity(ts::PhaseNonEquil) = ts.q.tot
 
 The isobaric specific heat capacity of moist
 air where, optionally,
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `q` [`PhasePartition`](@ref). Without this argument, the results are for dry air.
 """
 function cp_m(param_set::APS, q::PhasePartition{FT}) where {FT <: Real}
@@ -185,7 +185,7 @@ cp_m(ts::PhaseDry{FT}) where {FT <: Real} = FT(cp_d(ts.param_set))
 
 The isochoric specific heat capacity of moist
 air where optionally,
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `q` [`PhasePartition`](@ref). Without this argument, the results are for dry air.
 """
 function cv_m(param_set::APS, q::PhasePartition{FT}) where {FT <: Real}
@@ -216,7 +216,7 @@ cv_m(ts::PhaseDry{FT}) where {FT <: Real} = FT(cv_d(ts.param_set))
     (R_m, cp_m, cv_m, γ_m) = gas_constants(param_set, [q::PhasePartition])
 
 Wrapper to compute all gas constants at once, where optionally,
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `q` [`PhasePartition`](@ref). Without this argument, the results are for dry air.
 
 The function returns a tuple of
@@ -256,7 +256,7 @@ gas_constants(ts::ThermodynamicState) =
 
 The air temperature, where
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `e_int` internal energy per unit mass
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument, the results are for dry air.
@@ -290,7 +290,7 @@ air_temperature(ts::PhaseEquil) = ts.T
 
 The internal energy per unit mass, given a thermodynamic state `ts` or
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument, the results are for dry air.
@@ -342,7 +342,7 @@ end
 
 The internal energy per unit mass in thermodynamic equilibrium at saturation where
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
  - `ρ` (moist-)air density
  - `q_tot` total specific humidity
@@ -380,7 +380,7 @@ internal_energy_sat(ts::ThermodynamicState) = internal_energy_sat(
 
 The total energy per unit mass, given
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `e_kin` kinetic energy per unit mass
  - `e_pot` potential energy per unit mass
  - `T` temperature
@@ -416,7 +416,7 @@ end
     soundspeed_air(param_set, T[, q::PhasePartition])
 
 The speed of sound in unstratified air, where
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument, the results are for dry air.
@@ -444,7 +444,7 @@ soundspeed_air(ts::ThermodynamicState) =
     latent_heat_vapor(param_set, T::FT) where {FT<:Real}
 
 The specific latent heat of vaporization where
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
 """
 function latent_heat_vapor(param_set::APS, T::FT) where {FT <: Real}
@@ -467,7 +467,7 @@ latent_heat_vapor(ts::ThermodynamicState) =
     latent_heat_sublim(param_set, T::FT) where {FT<:Real}
 
 The specific latent heat of sublimation where
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
 """
 function latent_heat_sublim(param_set::APS, T::FT) where {FT <: Real}
@@ -490,7 +490,7 @@ latent_heat_sublim(ts::ThermodynamicState) =
     latent_heat_fusion(param_set, T::FT) where {FT<:Real}
 
 The specific latent heat of fusion where
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
 """
 function latent_heat_fusion(param_set::APS, T::FT) where {FT <: Real}
@@ -516,7 +516,7 @@ The specific latent heat of a generic phase transition between
 two phases, computed using Kirchhoff's relation with constant
 isobaric specific heat capacities of the two phases, given
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
  - `LH_0` latent heat of the phase transition at `T_0`
  - `Δcp` difference between the isobaric specific heat capacities
@@ -566,13 +566,13 @@ struct Ice <: Phase end
 
 Return the saturation vapor pressure over a plane liquid surface given
  - `T` temperature
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
 
     saturation_vapor_pressure(param_set, T, Ice())
 
 Return the saturation vapor pressure over a plane ice surface given
  - `T` temperature
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
 
     saturation_vapor_pressure(param_set, T, LH_0, Δcp)
 
@@ -670,7 +670,7 @@ end
 
 Compute the saturation specific humidity over a plane surface of condensate, given
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
  - `ρ` (moist-)air density
 and, optionally,
@@ -692,7 +692,7 @@ end
 
 Compute the saturation specific humidity, given
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
  - `ρ` (moist-)air density
 and, optionally,
@@ -756,7 +756,7 @@ q_vap_saturation(ts::ThermodynamicState) = q_vap_saturation(
 
 Compute the saturation specific humidity, given
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature,
  - `ρ` (moist-)air density
  - `p_v_sat` saturation vapor pressure
@@ -776,7 +776,7 @@ end
 
 The saturation excess in equilibrium where
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
  - `ρ` (moist-)air density
  - `q` [`PhasePartition`](@ref)
@@ -812,7 +812,7 @@ saturation_excess(ts::ThermodynamicState) = saturation_excess(
 
 The fraction of condensate that is liquid where
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
  - `q` [`PhasePartition`](@ref)
 
@@ -852,7 +852,7 @@ liquid_fraction(ts::ThermodynamicState) =
 Partition the phases in equilibrium, returning a [`PhasePartition`](@ref) object using the
 [`liquid_fraction`](@ref) function where
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
  - `ρ` (moist-)air density
  - `q_tot` total specific humidity
@@ -922,7 +922,7 @@ end
 
 Compute the temperature that is consistent with
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `e_int` internal energy
  - `ρ` (moist-)air density
  - `q_tot` total specific humidity
@@ -997,7 +997,7 @@ end
 
 Compute the temperature `T` that is consistent with
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `e_int` internal energy
  - `ρ` (moist-)air density
  - `q_tot` total specific humidity
@@ -1051,7 +1051,7 @@ end
 
 Compute the temperature `T` that is consistent with
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `θ_liq_ice` liquid-ice potential temperature
  - `q_tot` total specific humidity
  - `ρ` (moist-)air density
@@ -1115,7 +1115,7 @@ end
 
 Compute the temperature `T` that is consistent with
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `θ_liq_ice` liquid-ice potential temperature
  - `q_tot` total specific humidity
  - `p` pressure
@@ -1183,7 +1183,7 @@ end
 
 Effective latent heat of condensate (weighted sum of liquid and ice),
 with specific latent heat evaluated at reference temperature `T_0` given
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `q` [`PhasePartition`](@ref). Without this argument, the results are for dry air.
 """
 function latent_heat_liq_ice(
@@ -1200,7 +1200,7 @@ end
     liquid_ice_pottemp_given_pressure(param_set, T, p, q::PhasePartition)
 
 The liquid-ice potential temperature where
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
  - `p` pressure
 and, optionally,
@@ -1223,7 +1223,7 @@ end
     liquid_ice_pottemp(param_set, T, ρ, q::PhasePartition)
 
 The liquid-ice potential temperature where
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
  - `ρ` (moist-)air density
 and, optionally,
@@ -1261,7 +1261,7 @@ liquid_ice_pottemp(ts::ThermodynamicState) = liquid_ice_pottemp(
 
 The dry potential temperature where
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
  - `ρ` (moist-)air density
 and, optionally,
@@ -1281,7 +1281,7 @@ end
 
 The dry potential temperature where
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
  - `p` pressure
 and, optionally,
@@ -1312,7 +1312,7 @@ dry_pottemp(ts::ThermodynamicState) = dry_pottemp(
     air_temperature_from_liquid_ice_pottemp(param_set, θ_liq_ice, ρ, q::PhasePartition)
 
 The temperature given
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `θ_liq_ice` liquid-ice potential temperature
  - `ρ` (moist-)air density
 and, optionally,
@@ -1341,7 +1341,7 @@ end
 
 Computes temperature `T` given
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `θ_liq_ice` liquid-ice potential temperature
  - `ρ` (moist-)air density
  - `tol` tolerance for non-linear equation solve
@@ -1388,7 +1388,7 @@ end
 
 The air temperature where
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `θ_liq_ice` liquid-ice potential temperature
  - `p` pressure
 and, optionally,
@@ -1409,7 +1409,7 @@ end
 
 The virtual temperature where
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
  - `ρ` (moist-)air density
 and, optionally,
@@ -1444,7 +1444,7 @@ virtual_pottemp(ts::ThermodynamicState) = virtual_pottemp(
 
 The saturated liquid ice potential temperature where
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
  - `ρ` (moist-)air density
 and, optionally,
@@ -1465,7 +1465,7 @@ end
 
 The saturated liquid ice potential temperature where
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
  - `ρ` (moist-)air density
  - `q_tot` total specific humidity
@@ -1500,7 +1500,7 @@ liquid_ice_pottemp_sat(ts::ThermodynamicState) = liquid_ice_pottemp_sat(
     exner_given_pressure(param_set, p[, q::PhasePartition])
 
 The Exner function where
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `p` pressure
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument, the results are for dry air.
@@ -1522,7 +1522,7 @@ end
     exner(param_set, T, ρ[, q::PhasePartition)])
 
 The Exner function where
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
  - `ρ` (moist-)air density
 and, optionally,
@@ -1553,7 +1553,7 @@ exner(ts::ThermodynamicState) = exner(
     relative_humidity(param_set, T, p, e_int, q::PhasePartition)
 
 The relative humidity, given
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `p` pressure
  - `e_int` internal energy per unit mass
 and, optionally,

--- a/src/states.jl
+++ b/src/states.jl
@@ -123,7 +123,7 @@ PhaseDry(param_set::APS, e_int::FT, ρ::FT) where {FT} =
 
 Constructs a [`PhaseDry`](@ref) thermodynamic state from:
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `p` pressure
  - `T` temperature
 """
@@ -139,7 +139,7 @@ end
 
 Constructs a [`PhaseEquil`](@ref) thermodynamic state from:
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `θ_liq_ice` liquid-ice potential temperature
  - `ρ` (moist-)air density
  - `q_tot` total specific humidity
@@ -172,7 +172,7 @@ end
 
 Constructs a [`PhaseEquil`](@ref) thermodynamic state from:
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `θ_liq_ice` liquid-ice potential temperature
  - `p` pressure
  - `q_tot` total specific humidity
@@ -206,7 +206,7 @@ end
 
 Constructs a [`PhaseEquil`](@ref) thermodynamic state from temperature.
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
  - `p` pressure
  - `q_tot` total specific humidity
@@ -262,7 +262,7 @@ end
 
 Constructs a [`PhaseNonEquil`](@ref) thermodynamic state from:
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `θ_liq_ice` liquid-ice potential temperature
  - `ρ` (moist-)air density
  - `q_pt` phase partition
@@ -295,7 +295,7 @@ end
 
 Constructs a [`PhaseNonEquil`](@ref) thermodynamic state from:
 
- - `param_set` an `AbstractParameterSet`, see the [`MoistThermodynamics`](@ref) for more details
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `θ_liq_ice` liquid-ice potential temperature
  - `p` pressure
  - `q_pt` phase partition

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ rm(joinpath(@__DIR__, "..", "Manifest.toml"), force = true) # Remove local Manif
 
 test_env = joinpath(@__DIR__, "..", "env", "test")
 push!(LOAD_PATH, test_env)  # add test env
-push!(LOAD_PATH, joinpath(@__DIR__, ".."))                 # add MoistThermodynamics env
+push!(LOAD_PATH, joinpath(@__DIR__, ".."))                 # add Thermodynamics env
 
 using Pkg
 Pkg.activate(test_env)
@@ -10,10 +10,10 @@ Pkg.instantiate(; verbose = true)
 
 
 using Test
-using MoistThermodynamics
+using Thermodynamics
 using NCDatasets
 using Random
-MT = MoistThermodynamics
+MT = Thermodynamics
 
 using CLIMAParameters
 using CLIMAParameters.Planet

--- a/test/update_constructor_data.jl
+++ b/test/update_constructor_data.jl
@@ -1,10 +1,9 @@
 #=
 This file is for updating the NCDataset database that stores
-input values to the moist thermodynamic state constructors
+input values to the thermodynamic state constructors
 which have caused convergence issues. Updating this database
-allows us to optimize the convergence rate of the moist
-thermodynamics constructor for a variety of realistic input
-values.
+allows us to optimize the convergence rate of the thermodynamics
+constructor for a variety of realistic input values.
 =#
 
 using NCDatasets


### PR DESCRIPTION
It's been discussed that this package is useful beyond the moist atmosphere, and we should generalize the name to reflect this. This PR changes the package name from `MoistThermodynamics.jl` to `Thermodynamics.jl`.