### PR TITLE
Make tested profiles accessible in submodule

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Thermodynamics"
 uuid = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 authors = ["Climate Modeling Alliance"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.3.1"
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RootSolvers = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
 
 [compat]

--- a/docs/ThreeDimensionalInput.jl
+++ b/docs/ThreeDimensionalInput.jl
@@ -1,5 +1,6 @@
 using Thermodynamics
 using Thermodynamics.TemperatureProfiles
+using Thermodynamics.TestedProfiles
 using UnPack
 using CLIMAParameters
 using CLIMAParameters.Planet
@@ -11,9 +12,8 @@ struct EarthParameterSet <: AbstractEarthParameterSet end;
 const param_set = EarthParameterSet();
 FT = Float64;
 thermo_dir = dirname(dirname(pathof(Thermodynamics)));
-include(joinpath(thermo_dir, "test", "profiles.jl"))
 include(joinpath(thermo_dir, "docs", "plot_helpers.jl"));
-profiles = PhaseEquilProfiles(param_set, Array{FT});
+profiles = TestedProfiles.PhaseEquilProfiles(param_set, Array{FT});
 @unpack ρ, e_int, q_tot = profiles
 
 dims = (10, 10, 10);

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -104,3 +104,9 @@ TemperatureProfiles.TemperatureProfile
 TemperatureProfiles.DryAdiabaticProfile
 TemperatureProfiles.DecayingTemperatureProfile
 ```
+
+## Tested profiles
+
+```@docs
+Thermodynamics.TestedProfiles
+```

--- a/docs/src/TestedProfiles.md
+++ b/docs/src/TestedProfiles.md
@@ -1,12 +1,13 @@
 # Tested Profiles
 
-Thermodynamics.jl is tested using a set of profiles specified in `test/profiles.jl`.
+Thermodynamics.jl is tested using a set of profiles specified in `src/TestedProfiles.jl`.
 
 ## Dry Phase
 
 ```@example
 using Thermodynamics
 using Thermodynamics.TemperatureProfiles
+using Thermodynamics.TestedProfiles
 using UnPack
 using CLIMAParameters
 using CLIMAParameters.Planet
@@ -14,8 +15,7 @@ using Plots
 struct EarthParameterSet <: AbstractEarthParameterSet end;
 const param_set = EarthParameterSet();
 thermo_dir = dirname(dirname(pathof(Thermodynamics)));
-include(joinpath(thermo_dir, "test", "profiles.jl"))
-profiles = PhaseDryProfiles(param_set, Array{Float32});
+profiles = TestedProfiles.PhaseDryProfiles(param_set, Array{Float32});
 @unpack T, ρ, z = profiles
 p1 = scatter(ρ, z./10^3, xlabel="Density [kg/m^3]", ylabel="z [km]", title="Density");
 p2 = scatter(T, z./10^3, xlabel="Temperature [K]", ylabel="z [km]", title="Temperature");
@@ -29,6 +29,7 @@ savefig("tested_profiles_dry.svg");
 ```@example
 using Thermodynamics
 using Thermodynamics.TemperatureProfiles
+using Thermodynamics.TestedProfiles
 using UnPack
 using CLIMAParameters
 using CLIMAParameters.Planet
@@ -36,8 +37,7 @@ using Plots
 struct EarthParameterSet <: AbstractEarthParameterSet end;
 const param_set = EarthParameterSet();
 thermo_dir = dirname(dirname(pathof(Thermodynamics)));
-include(joinpath(thermo_dir, "test", "profiles.jl"))
-profiles = PhaseEquilProfiles(param_set, Array{Float32});
+profiles = TestedProfiles.PhaseEquilProfiles(param_set, Array{Float32});
 @unpack T, ρ, q_tot, z = profiles
 p1 = scatter(ρ, z./10^3, xlabel="Density [kg/m^3]", ylabel="z [km]", title="Density");
 p2 = scatter(T, z./10^3, xlabel="Temperature [K]", ylabel="z [km]", title="Temperature");

--- a/src/TestedProfiles.jl
+++ b/src/TestedProfiles.jl
@@ -1,11 +1,18 @@
-#### Tested moist thermodynamic profiles
+"""
+    TestedProfiles
 
-#=
-This file contains functions to compute all of the
+Tested thermodynamic profiles
+
+This module contains functions to compute all of the
 thermodynamic _states_ that Thermodynamics is
 tested with in runtests.jl
-=#
+"""
+module TestedProfiles
 
+using ..Thermodynamics
+using ..Thermodynamics.TemperatureProfiles
+using CLIMAParameters: AbstractParameterSet
+using CLIMAParameters.Planet
 using Random
 
 """
@@ -60,30 +67,6 @@ function Base.iterate(ps::ProfileSet, state = 1)
 end
 Base.IteratorSize(::ProfileSet) = Base.HasLength()
 Base.length(ps::ProfileSet) = length(ps.z)
-
-# Since we use `rand` to generate the ProfileSet,
-# just initialize on the CPU, and provide convert
-# function to move arrays to the GPU.
-convert_profile_set(ps::ProfileSet, ArrayType, slice) = ProfileSet(
-    ArrayType(ps.z[slice]),
-    ArrayType(ps.T[slice]),
-    ArrayType(ps.p[slice]),
-    ArrayType(ps.RS[slice]),
-    ArrayType(ps.e_int[slice]),
-    ArrayType(ps.ρ[slice]),
-    ArrayType(ps.θ_liq_ice[slice]),
-    ArrayType(ps.q_tot[slice]),
-    ArrayType(ps.q_liq[slice]),
-    ArrayType(ps.q_ice[slice]),
-    PhasePartition.(ps.q_tot[slice], ps.q_liq[slice], ps.q_ice[slice]),
-    ArrayType(ps.RH[slice]),
-    ArrayType(ps.e_pot[slice]),
-    ArrayType(ps.u[slice]),
-    ArrayType(ps.v[slice]),
-    ArrayType(ps.w[slice]),
-    ArrayType(ps.e_kin[slice]),
-    ps.phase_type,
-)
 
 """
     input_config(
@@ -296,3 +279,5 @@ function PhaseEquilProfiles(
         phase_type,
     )
 end
+
+end # module

--- a/src/Thermodynamics.jl
+++ b/src/Thermodynamics.jl
@@ -74,6 +74,7 @@ include("relations.jl")
 include("isentropic.jl")
 include("config_numerical_method.jl")
 include("TemperatureProfiles.jl")
+include("TestedProfiles.jl")
 
 Base.broadcastable(dap::DryAdiabaticProcess) = Ref(dap)
 Base.broadcastable(phase::Phase) = Ref(phase)

--- a/test/relations.jl
+++ b/test/relations.jl
@@ -1,6 +1,7 @@
 using Test
 using Thermodynamics
 using Thermodynamics.TemperatureProfiles
+using Thermodynamics.TestedProfiles
 using UnPack
 using BenchmarkTools
 using NCDatasets
@@ -26,7 +27,6 @@ rtol_energy = 1e-1
 
 array_types = [Array{Float32}, Array{Float64}]
 
-include("profiles.jl")
 include("data_tests.jl")
 
 compare_moisture(a::ThermodynamicState, b::ThermodynamicState) =
@@ -70,7 +70,7 @@ compare_moisture(ts::PhaseNonEquil, q_pt::PhasePartition) = all((
         _T_max = FT(T_max(param_set))
         _kappa_d = FT(kappa_d(param_set))
 
-        profiles = PhaseEquilProfiles(param_set, ArrayType)
+        profiles = TestedProfiles.PhaseEquilProfiles(param_set, ArrayType)
         @unpack T, p, RS, e_int, ρ, θ_liq_ice, phase_type = profiles
         @unpack q_tot, q_liq, q_ice, q_pt, RH, e_kin, e_pot = profiles
 
@@ -458,7 +458,7 @@ end
     or(a, b) = a || b
     for ArrayType in array_types
         FT = eltype(ArrayType)
-        profiles = PhaseEquilProfiles(param_set, ArrayType)
+        profiles = TestedProfiles.PhaseEquilProfiles(param_set, ArrayType)
         @unpack T, p, RS, e_int, ρ, θ_liq_ice, phase_type = profiles
         @unpack q_tot, q_liq, q_ice, q_pt, RH, e_kin, e_pot = profiles
 
@@ -642,7 +642,7 @@ end
 
     ArrayType = Array{Float64}
     FT = eltype(ArrayType)
-    profiles = PhaseEquilProfiles(param_set, ArrayType)
+    profiles = TestedProfiles.PhaseEquilProfiles(param_set, ArrayType)
     @unpack T, p, RS, e_int, ρ, θ_liq_ice, phase_type = profiles
     @unpack q_tot, q_liq, q_ice, q_pt, RH, e_kin, e_pot = profiles
 
@@ -740,7 +740,7 @@ end
         FT = eltype(ArrayType)
         _MSLP = FT(MSLP(param_set))
 
-        profiles = PhaseDryProfiles(param_set, ArrayType)
+        profiles = TestedProfiles.PhaseDryProfiles(param_set, ArrayType)
         @unpack T, p, RS, e_int, ρ, θ_liq_ice, phase_type = profiles
         @unpack q_tot, q_liq, q_ice, q_pt, RH, e_kin, e_pot = profiles
 
@@ -780,7 +780,7 @@ end
         @test all(total_energy.(e_kin, e_pot, ts) .≈ e_tot_proposed)
 
 
-        profiles = PhaseEquilProfiles(param_set, ArrayType)
+        profiles = TestedProfiles.PhaseEquilProfiles(param_set, ArrayType)
         @unpack T, p, RS, e_int, ρ, θ_liq_ice, phase_type = profiles
         @unpack q_tot, q_liq, q_ice, q_pt, RH, e_kin, e_pot = profiles
 
@@ -924,7 +924,7 @@ end
         @test all(air_density.(ts) .≈ ρ)
         @test all(compare_moisture.(ts, q_pt))
 
-        profiles = PhaseEquilProfiles(param_set, ArrayType)
+        profiles = TestedProfiles.PhaseEquilProfiles(param_set, ArrayType)
         @unpack T, p, RS, e_int, ρ, θ_liq_ice, phase_type = profiles
         @unpack q_tot, q_liq, q_ice, q_pt, RH, e_kin, e_pot = profiles
 
@@ -1003,7 +1003,7 @@ end
     # with converging to the same tolerances as `Float64`, so they're relaxed here.
     ArrayType = Array{Float32}
     FT = eltype(ArrayType)
-    profiles = PhaseEquilProfiles(param_set, ArrayType)
+    profiles = TestedProfiles.PhaseEquilProfiles(param_set, ArrayType)
     @unpack T, p, RS, e_int, ρ, θ_liq_ice, phase_type = profiles
     @unpack q_tot, q_liq, q_ice, q_pt, RH, e_kin, e_pot = profiles
 
@@ -1122,7 +1122,7 @@ end
 
     ArrayType = Array{Float64}
     FT = eltype(ArrayType)
-    profiles = PhaseEquilProfiles(param_set, ArrayType)
+    profiles = TestedProfiles.PhaseEquilProfiles(param_set, ArrayType)
     @unpack T, p, RS, e_int, ρ, θ_liq_ice, phase_type = profiles
     @unpack q_tot, q_liq, q_ice, q_pt, RH, e_kin, e_pot = profiles
 
@@ -1198,7 +1198,7 @@ end
 @testset "Thermodynamics - ProfileSet Iterator" begin
     ArrayType = Array{Float64}
     FT = eltype(ArrayType)
-    profiles = PhaseEquilProfiles(param_set, ArrayType)
+    profiles = TestedProfiles.PhaseEquilProfiles(param_set, ArrayType)
     @unpack T, q_pt, z, phase_type = profiles
     @test all(z .≈ (nt.z for nt in profiles))
     @test all(T .≈ (nt.T for nt in profiles))
@@ -1209,8 +1209,7 @@ end
 @testset "Thermodynamics - Performance" begin
     ArrayType = Array{Float64}
     FT = eltype(ArrayType)
-    profiles = PhaseEquilProfiles(param_set, ArrayType)
-
+    profiles = TestedProfiles.PhaseEquilProfiles(param_set, ArrayType)
     @unpack e_int, ρ, q_tot = profiles
 
     @btime TD.PhaseEquil_dev_only.(


### PR DESCRIPTION
ClimateMachine.jl [uses Thermodynamics.jl's tested profiles](https://github.com/CliMA/ClimateMachine.jl/blob/master/test/Atmos/prog_prim_conversion/runtests.jl#L110) for primitive-prognostic conversions. This PR makes those profiles available via a submodule in `src/`.