### PR TITLE
Add psq constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RootSolvers = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
 
 [compat]
-CLIMAParameters = "0.1.0"
 DocStringExtensions = "0.8.1"
 KernelAbstractions = "0.5, 0.6"
 RootSolvers = "0.2"

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -13,6 +13,17 @@
   publisher = {American Meteorological Society}
 }
 
+@article{Chase1996,
+  title = {NIST-JANAF thermochemical tables for oxygen fluorides},
+  author = {Chase, Malcolm W},
+  journal = {Journal of physical and chemical reference data},
+  volume = {25},
+  number = {2},
+  pages = {551--603},
+  year = {1996},
+  publisher = {American Institute of Physics for the National Institute of Standards and~…}
+}
+
 @incollection{Durran1999,
   title = {Finite-Volume Methods},
   author = {Durran, Dale R},
@@ -20,6 +31,17 @@
   pages = {241--302},
   year = {1999},
   publisher = {Springer}
+}
+
+@article{Lemmon2000,
+  title = {Thermodynamic properties of air and mixtures of nitrogen, argon, and oxygen from 60 to 2000 K at pressures to 2000 MPa},
+  author = {Lemmon, Eric W and Jacobsen, Richard T and Penoncello, Steven G and Friend, Daniel G},
+  journal = {Journal of physical and chemical reference data},
+  volume = {29},
+  number = {3},
+  pages = {331--385},
+  year = {2000},
+  publisher = {American Institute of Physics for the National Institute of Standards and~…}
 }
 
 @article{Marquet2015,

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -25,6 +25,7 @@ PhaseEquil_ρTq
 PhaseEquil_pTq
 PhaseEquil_pθq
 PhaseEquil_peq
+PhaseEquil_psq
 PhaseEquil_ρθq
 PhaseEquil_ρpq
 PhaseNonEquil
@@ -45,6 +46,7 @@ condensate
 cp_m
 cv_m
 dry_pottemp
+entropy
 exner
 gas_constant_air
 gas_constants

--- a/src/TestedProfiles.jl
+++ b/src/TestedProfiles.jl
@@ -38,6 +38,7 @@ struct ProfileSet{AFT, QPT, PT}
     v::AFT          # velocity (y component)
     w::AFT          # velocity (z component)
     e_kin::AFT      # kinetic energy
+    s::AFT          # entropy
     phase_type::PT  # Phase type (e.g., `PhaseDry`, `PhaseEquil`)
 end
 
@@ -61,6 +62,7 @@ function Base.iterate(ps::ProfileSet, state = 1)
         v = ps.v[state],
         w = ps.w[state],
         e_kin = ps.e_kin[state],
+        s = ps.s[state],
         phase_type = ps.phase_type,
     )
     return (nt, state + 1)
@@ -185,6 +187,7 @@ function PhaseDryProfiles(
     v = rand(FT, size(T)) * 50
     w = rand(FT, size(T)) * 50
     e_kin = (u .^ 2 .+ v .^ 2 .+ w .^ 2) / 2
+    s = entropy.(param_set, p, T, q_pt)
 
 
     return ProfileSet{typeof(T), typeof(q_pt), typeof(phase_type)}(
@@ -205,6 +208,7 @@ function PhaseDryProfiles(
         v,
         w,
         e_kin,
+        s,
         phase_type,
     )
 end
@@ -257,6 +261,7 @@ function PhaseEquilProfiles(
     v = rand(FT, size(T)) * 50
     w = rand(FT, size(T)) * 50
     e_kin = (u .^ 2 .+ v .^ 2 .+ w .^ 2) / 2
+    s = entropy.(param_set, p, T, q_pt)
 
     return ProfileSet{typeof(T), typeof(q_pt), typeof(phase_type)}(
         z,
@@ -276,6 +281,7 @@ function PhaseEquilProfiles(
         v,
         w,
         e_kin,
+        s,
         phase_type,
     )
 end

--- a/src/config_numerical_method.jl
+++ b/src/config_numerical_method.jl
@@ -151,3 +151,20 @@ function sa_numerical_method_peq(
     T_2 = bound_upper_temperature(T_1, T_2)
     return SecantMethod(T_1, T_2)
 end
+
+#####
+##### Thermodynamic variable inputs: p, s, q_tot
+#####
+
+function sa_numerical_method_psq(
+    ::Type{NM},
+    param_set::APS,
+    p::FT,
+    s::FT,
+    q_tot::FT,
+    phase_type::Type{<:PhaseEquil},
+) where {FT, NM <: RegulaFalsiMethod}
+    T_1 = FT(T_min(param_set))
+    T_2 = FT(T_max(param_set))
+    return RegulaFalsiMethod(T_1, T_2)
+end

--- a/src/relations.jl
+++ b/src/relations.jl
@@ -58,6 +58,7 @@ export specific_enthalpy
 export total_specific_enthalpy
 export moist_static_energy
 export saturated
+export entropy
 
 heavisided(x) = (x > 0) * x
 
@@ -144,6 +145,94 @@ function air_density(
 ) where {FT <: Real}
     return p / (gas_constant_air(param_set, q) * T)
 end
+
+"""
+    air_density_equil(
+        param_set,
+        T,
+        p,
+        q_tot,
+    )
+
+Compute the (equilibrium-)air density `ρ` that is consistent with
+
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
+ - `T` temperature
+ - `p` pressure
+ - `q_tot` total specific humidity
+
+by finding the root of
+
+```
+ρ - air_density(
+    param_set,
+    T,
+    p,
+    PhasePartition_equil(param_set, T, ρ, q_tot, PhaseEquil)
+)
+```
+
+This air density is in sync with that computed from `air_density`,
+which relies on the full `PhasePartition`.
+
+See also [`saturation_adjustment`](@ref).
+
+!!! warn
+    This is an expensive function, and has internalized
+    iterative solver parameters to simplify the interface.
+"""
+function air_density_equil(
+    param_set::APS,
+    T::FT,
+    p::FT,
+    q_tot::FT,
+) where {FT <: Real}
+    # Assume all liquid
+    ρ_init = air_density(param_set, T, p, PhasePartition(q_tot))
+    phase_type = PhaseEquil
+    maxiter = 50
+    tol = SolutionTolerance(eps(FT))
+    sol = find_zero(
+        ρ -> begin
+            _q_tot = oftype(ρ, q_tot)
+            _p = oftype(ρ, p)
+
+            q_pt = PhasePartition_equil(
+                param_set,
+                oftype(ρ, T),
+                ρ,
+                oftype(ρ, q_tot),
+                phase_type,
+            )
+            # TODO: is one of these equations preferred over the other?
+            # (e.g., physically / numerically)
+            # T - air_temperature_from_ideal_gas_law(param_set, _p, ρ, q_pt)
+            ρ - air_density(param_set, oftype(ρ, T), _p, q_pt)
+        end,
+        NewtonsMethodAD(ρ_init),
+        CompactSolution(),
+        tol,
+        maxiter,
+    )
+    if !sol.converged
+        if print_warning()
+            @print("-----------------------------------------\n")
+            @print("maxiter reached in air_density_equil:\n")
+            @print("    Method=NewtonsMethodAD")
+            @print(", T=", T)
+            @print(", p=", p)
+            @print(", q_tot=", q_tot)
+            @print(", ρ=", sol.root)
+            @print(", maxiter=", maxiter)
+            @print(", tol=", tol.tol, "\n")
+        end
+        if error_on_non_convergence()
+            error("Failed to converge with printed set of inputs.")
+        end
+    end
+    return sol.root
+end
+
 
 """
     air_density(ts::ThermodynamicState)
@@ -1497,6 +1586,123 @@ function saturation_adjustment_given_peq(
 end
 
 """
+    saturation_adjustment_psq(
+        sat_adjust_method,
+        param_set,
+        s,
+        p,
+        q_tot,
+        phase_type,
+        maxiter,
+        temperature_tol
+    )
+
+Compute the temperature that is consistent with
+
+ - `sat_adjust_method` the numerical method to use.
+    See the [`Thermodynamics`](@ref) for options.
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
+ - `s` entropy
+ - `p` air pressure
+ - `q_tot` total specific humidity
+ - `phase_type` a thermodynamic state type
+ - `maxiter` maximum iterations for non-linear equation solve
+ - `temperature_tol` temperature tolerance
+
+by finding the root of
+
+`s - entropy(param_set, p, T, q) = 0`
+
+using the given numerical method `sat_adjust_method`.
+
+See also [`saturation_adjustment`](@ref).
+"""
+function saturation_adjustment_psq(
+    ::Type{sat_adjust_method},
+    param_set::APS,
+    p::FT,
+    s::FT,
+    q_tot::FT,
+    phase_type::Type{<:PhaseEquil},
+    maxiter::Int,
+    temperature_tol::FT,
+) where {FT <: Real, sat_adjust_method}
+    _T_min::FT = T_min(param_set)
+    _T_max::FT = T_max(param_set)
+    tol = SolutionTolerance(temperature_tol)
+
+    # TODO: use better T_1 estimate
+    T_1 = _T_min # Assume all vapor
+    ρ_T(T) = air_density(param_set, T, p, PhasePartition(q_tot))
+    ρ_1 = ρ_T(T_1)
+    q_v_sat = q_vap_saturation(param_set, T_1, ρ_1, phase_type)
+    unsaturated = q_tot <= q_v_sat
+    if unsaturated && T_1 > _T_min
+        return T_1
+    else
+
+        _T_freeze::FT = T_freeze(param_set)
+        s_upper = entropy_pTq(
+            param_set,
+            p,
+            _T_freeze + temperature_tol / 2, # /2 => resulting interval is `temperature_tol` wide
+            q_tot,
+            phase_type,
+        )
+        s_lower = entropy_pTq(
+            param_set,
+            p,
+            _T_freeze - temperature_tol / 2, # /2 => resulting interval is `temperature_tol` wide
+            q_tot,
+            phase_type,
+        )
+        if s_lower < s < s_upper
+            return _T_freeze
+        end
+        sol = find_zero(
+            T -> begin
+                _q_tot = oftype(T, q_tot)
+                _p = oftype(T, p)
+
+                _T = heavisided(T)
+                _T = max(_T, _T_min)
+                _T = min(_T, _T_max)
+
+                entropy_pTq(param_set, _p, _T, _q_tot, phase_type) - s
+            end,
+            sa_numerical_method_psq(
+                sat_adjust_method,
+                param_set,
+                p,
+                s,
+                q_tot,
+                phase_type,
+            ),
+            CompactSolution(),
+            tol,
+            maxiter,
+        )
+        if !sol.converged
+            if print_warning()
+                @print("-----------------------------------------\n")
+                @print("maxiter reached in saturation_adjustment_psq:\n")
+                print_numerical_method(sat_adjust_method)
+                @print(", p=", p)
+                @print(", s=", s)
+                @print(", q_tot=", q_tot)
+                @print(", T=", sol.root)
+                @print(", maxiter=", maxiter)
+                @print(", tol=", tol.tol, "\n")
+            end
+            if error_on_non_convergence()
+                error("Failed to converge with printed set of inputs.")
+            end
+        end
+        return sol.root
+    end
+end
+
+"""
     saturation_adjustment_ρpq(
         sat_adjust_method,
         param_set,
@@ -2480,3 +2686,66 @@ function saturated(ts::ThermodynamicState)
     RH = relative_humidity(ts)
     return RH ≈ 1 || RH > 1
 end
+
+
+"""
+    entropy(param_set::APS, p::FT, T::FT, q::PhasePartition{FT}) where {FT}
+    entropy(ts::ThermodynamicState)
+
+Thermodynamic entropy, given
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
+ - `p` air pressure
+ - `T` air temperature
+ - `q` [`PhasePartition`](@ref). Without this argument, the results are for dry air.
+
+The standard entropy value for dry air is computed based
+on the reference data given in [Lemmon2000](@cite), and
+the standard entropy value for water vapor is based on
+the reference data given in [Chase1996](@cite).
+"""
+function entropy(param_set::APS, p::FT, T::FT, q::PhasePartition{FT}) where {FT}
+    ps = param_set
+    s̃_d = FT(entropy_dry_air(ps))
+    s̃_v = FT(entropy_water_vapor(ps))
+    T̃ = FT(entropy_reference_temperature(ps))
+    p̃ = FT(MSLP(ps))
+    q_tot = q.tot
+    q_liq = q.liq
+    q_ice = q.ice
+    εᵥ⁻¹ = FT(R_v(ps)) / FT(R_d(ps))
+    q_vap = q_tot - (q_liq + q_ice)
+    p_d = p * (1 - q_tot) / (1 - q_tot + εᵥ⁻¹ * q_vap)
+    p_v = p * (εᵥ⁻¹ * q_tot) / (1 - q_tot + εᵥ⁻¹ * q_vap)
+    s_d = s̃_d + FT(cp_d(ps)) * log(T / T̃) - FT(R_d(ps)) * log(p_d / p̃)
+    p_v_by_p̃ = p_v / p̃
+    if p_v_by_p̃ < eps(FT) # avoid log(0)
+        s_v = FT(0)
+    else
+        s_v = s̃_v + FT(cp_v(ps)) * log(T / T̃) - FT(R_v(ps)) * log(p_v_by_p̃)
+    end
+    L_v = latent_heat_vapor(ps, T)
+    L_s = latent_heat_sublim(ps, T)
+    res = (1 - q_tot) * s_d + q_tot * s_v - (q_liq * L_v + q_ice * L_s) / T
+    return res
+end
+entropy(param_set::APS, p::FT, T::FT) where {FT} =
+    entropy(param_set, p, T, PhasePartition{FT}(0, 0, 0))
+
+function entropy_pTq(
+    param_set::APS,
+    p::FT,
+    T::FT,
+    q_tot::FT,
+    phase_type::Type{<:PhaseEquil},
+) where {FT}
+    ρ = air_density_equil(param_set, T, p, q_tot)
+    q_eq = PhasePartition_equil(param_set, T, ρ, q_tot, phase_type)
+    return entropy(param_set, p, T, q_eq)
+end
+
+entropy(ts::ThermodynamicState) = entropy(
+    ts.param_set,
+    air_pressure(ts),
+    air_temperature(ts),
+    PhasePartition(ts),
+)

--- a/test/runtests_gpu.jl
+++ b/test/runtests_gpu.jl
@@ -77,6 +77,7 @@ convert_profile_set(ps::ProfileSet, ArrayType, slice) = ProfileSet(
     ArrayType(ps.v[slice]),
     ArrayType(ps.w[slice]),
     ArrayType(ps.e_kin[slice]),
+    ArrayType(ps.s[slice]),
     ps.phase_type,
 )
 


### PR DESCRIPTION
This PR adds a new constructor, `PhaseEquil_psq`, and tests it for the newly added `entropy` profiles.

In addition, this PR add `air_density_equil`, which seems to be important for the consistency of `PhaseEquil_psq` and may be useful elsewhere.