### PR TITLE
Rename PhaseEquil outer constructor to PhaseEquil_ρeq, change arg order

### DIFF
--- a/docs/ThreeDimensionalInput.jl
+++ b/docs/ThreeDimensionalInput.jl
@@ -38,11 +38,11 @@ TS_no_err = Array{ThermodynamicState}(undef, prod(dims));
             q_tot_all[p] = q_tot[k]
 
             Thermodynamics.error_on_non_convergence() = false
-            TS_no_err[p] = PhaseEquil(param_set, e_int[j], ρ[i], q_tot[k])
+            TS_no_err[p] = PhaseEquil_ρeq(param_set, ρ[i], e_int[j], q_tot[k])
             Thermodynamics.error_on_non_convergence() = true
             # @show p/prod(linear_indices.indices)*100
             try
-                TS[p] = PhaseEquil(param_set, e_int[j], ρ[i], q_tot[k])
+                TS[p] = PhaseEquil_ρeq(param_set, ρ[i], e_int[j], q_tot[k])
             catch
                 TS[p] = nothing
             end

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -21,6 +21,7 @@ PhaseDry_ρθ
 PhaseDry_ρT
 PhaseDry_ρp
 PhaseEquil
+PhaseEquil_ρeq
 PhaseEquil_ρTq
 PhaseEquil_pTq
 PhaseEquil_pθq

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -62,7 +62,7 @@ Users are encouraged to first establish a thermodynamic state with one of our
 a moist thermodynamic state using
 
 ```julia
-ts = PhaseEquil(param_set, e_int, ρ, q_tot);
+ts = PhaseEquil_ρeq(param_set, ρ, e_int, q_tot);
 ```
 
 here, `ρ` is the density of the moist air, and the internal energy `e_int =
@@ -102,7 +102,7 @@ do timestep   # timestepping loop
   e_int = e_tot - 0.5 * (u^2 + v^2 + w^2) - geopotential
 
   # compute temperature, pressure and condensate specific humidities,
-  ts = PhaseEquil(param_set, e_int, ρ, q_tot);
+  ts = PhaseEquil_ρeq(param_set, ρ, e_int, q_tot);
   T = air_temperature(ts);
   q = PhasePartition(ts);
   p = air_pressure(ts);

--- a/src/relations.jl
+++ b/src/relations.jl
@@ -1645,10 +1645,10 @@ function saturation_adjustment_given_ρθq(
     _T_min::FT = T_min(param_set)
     T_1 = max(
         _T_min,
-        air_temperature_given_θρq(
+        air_temperature_given_ρθq(
             param_set,
-            θ_liq_ice,
             ρ,
+            θ_liq_ice,
             PhasePartition(q_tot),
         ),
     ) # Assume all vapor
@@ -1657,10 +1657,10 @@ function saturation_adjustment_given_ρθq(
     if unsaturated && T_1 > _T_min
         return T_1
     else
-        T_2 = air_temperature_given_θρq(
+        T_2 = air_temperature_given_ρθq(
             param_set,
-            θ_liq_ice,
             ρ,
+            θ_liq_ice,
             PhasePartition(q_tot, FT(0), q_tot),
         ) # Assume all ice
         T_2 = bound_upper_temperature(T_1, T_2)
@@ -1741,10 +1741,10 @@ function saturation_adjustment_given_pθq(
     tol::AbstractTolerance,
 ) where {FT <: Real}
     _T_min::FT = T_min(param_set)
-    T_1 = air_temperature_given_θpq(
+    T_1 = air_temperature_given_pθq(
         param_set,
-        θ_liq_ice,
         p,
+        θ_liq_ice,
         PhasePartition(q_tot),
     ) # Assume all vapor
     ρ = air_density(param_set, T_1, p, PhasePartition(q_tot))
@@ -1753,10 +1753,10 @@ function saturation_adjustment_given_pθq(
     if unsaturated && T_1 > _T_min
         return T_1
     else
-        T_2 = air_temperature_given_θpq(
+        T_2 = air_temperature_given_pθq(
             param_set,
-            θ_liq_ice,
             p,
+            θ_liq_ice,
             PhasePartition(q_tot, FT(0), q_tot),
         ) # Assume all ice
         T_2 = bound_upper_temperature(T_1, T_2)
@@ -2000,7 +2000,7 @@ function temperature_and_humidity_given_TᵥρRH(
 end
 
 """
-    air_temperature_given_θρq(param_set, θ_liq_ice, ρ, q::PhasePartition)
+    air_temperature_given_ρθq(param_set, ρ, θ_liq_ice, q::PhasePartition)
 
 The temperature given
  - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
@@ -2009,10 +2009,10 @@ The temperature given
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument, the results are for dry air.
 """
-function air_temperature_given_θρq(
+function air_temperature_given_ρθq(
     param_set::APS,
-    θ_liq_ice::FT,
     ρ::FT,
+    θ_liq_ice::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
 ) where {FT <: Real}
 
@@ -2028,7 +2028,7 @@ function air_temperature_given_θρq(
 end
 
 """
-    air_temperature_given_θρq_nonlinear(param_set, θ_liq_ice, ρ, q::PhasePartition)
+    air_temperature_given_ρθq_nonlinear(param_set, ρ, θ_liq_ice, q::PhasePartition)
 
 Computes temperature `T` given
 
@@ -2043,15 +2043,15 @@ and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument, the results are for dry air,
 
 by finding the root of
-`T - air_temperature_given_θpq(param_set,
-                               θ_liq_ice,
+`T - air_temperature_given_pθq(param_set,
                                air_pressure(param_set, T, ρ, q),
+                               θ_liq_ice,
                                q) = 0`
 """
-function air_temperature_given_θρq_nonlinear(
+function air_temperature_given_ρθq_nonlinear(
     param_set::APS,
-    θ_liq_ice::FT,
     ρ::FT,
+    θ_liq_ice::FT,
     maxiter::Int,
     tol::AbstractTolerance,
     q::PhasePartition{FT} = q_pt_0(FT),
@@ -2060,10 +2060,10 @@ function air_temperature_given_θρq_nonlinear(
     _T_max::FT = T_max(param_set)
     sol = find_zero(
         T ->
-            T - air_temperature_given_θpq(
+            T - air_temperature_given_pθq(
                 param_set,
-                θ_liq_ice,
                 air_pressure(param_set, heavisided(T), ρ, q),
+                θ_liq_ice,
                 q,
             ),
         SecantMethod(_T_min, _T_max),
@@ -2074,7 +2074,7 @@ function air_temperature_given_θρq_nonlinear(
     if !sol.converged
         if print_warning()
             @print("-----------------------------------------\n")
-            @print("maxiter reached in air_temperature_given_θρq_nonlinear:\n")
+            @print("maxiter reached in air_temperature_given_ρθq_nonlinear:\n")
             @print("    Method=SecantMethod")
             @print(", θ_liq_ice=", θ_liq_ice)
             @print(", ρ=", ρ)
@@ -2093,10 +2093,11 @@ function air_temperature_given_θρq_nonlinear(
 end
 
 """
-    air_temperature_given_θpq(
+    air_temperature_given_pθq(
         param_set,
+        p,
         θ_liq_ice,
-        p[, q::PhasePartition]
+        [q::PhasePartition]
     )
 
 The air temperature where
@@ -2107,10 +2108,10 @@ The air temperature where
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument, the results are for dry air.
 """
-function air_temperature_given_θpq(
+function air_temperature_given_pθq(
     param_set::APS,
-    θ_liq_ice::FT,
     p::FT,
+    θ_liq_ice::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
 ) where {FT <: Real}
     return θ_liq_ice * exner_given_pressure(param_set, p, q) +

--- a/test/data_tests.jl
+++ b/test/data_tests.jl
@@ -24,6 +24,6 @@ dycoms_dataset_path = get_data_folder(dycoms_dataset)
     ρ = Array{FT}(ds_PhaseEquil["ρ"][:])
     q_tot = Array{FT}(ds_PhaseEquil["q_tot"][:])
 
-    ts = PhaseEquil.(Ref(param_set), e_int, ρ, q_tot, 4)
-    # ts = PhaseEquil.(Ref(param_set), e_int, ρ, q_tot, 3) # Fails
+    ts = PhaseEquil_ρeq.(Ref(param_set), ρ, e_int, q_tot, 4)
+    # ts = PhaseEquil_ρeq.(Ref(param_set), ρ, e_int, q_tot, 3) # Fails
 end

--- a/test/runtests_gpu.jl
+++ b/test/runtests_gpu.jl
@@ -40,7 +40,7 @@ end
     i = @index(Group, Linear)
     @inbounds begin
 
-        ts = PhaseEquil(param_set, FT(e_int[i]), FT(ρ[i]), FT(q_tot[i]))
+        ts = PhaseEquil_ρeq(param_set, FT(ρ[i]), FT(e_int[i]), FT(q_tot[i]))
         dst[1, i] = air_temperature(ts)
 
         ts_ρpq = PhaseEquil_ρpq(
@@ -100,7 +100,8 @@ convert_profile_set(ps::ProfileSet, ArrayType, slice) = ProfileSet(
     event = kernel!(param_set, d_dst, e_int, ρ, p, q_tot, ndrange = ndrange)
     wait(dev, event)
 
-    ts_correct = PhaseEquil.(param_set, Array(e_int), Array(ρ), Array(q_tot))
+    ts_correct =
+        PhaseEquil_ρeq.(param_set, Array(ρ), Array(e_int), Array(q_tot))
     @test all(Array(d_dst)[1, :] .≈ air_temperature.(ts_correct))
 
     ts_correct =

--- a/test/update_constructor_data.jl
+++ b/test/update_constructor_data.jl
@@ -35,7 +35,7 @@ folder = joinpath(@__DIR__, "MTConstructorData")
 output_file = joinpath(@__DIR__, "MTConstructorDataZipped.tar.gz")
 mkpath(folder)
 
-constructors = Dict("PhaseEquil" => (:e_int, :ρ, :q_tot))
+constructors = Dict("PhaseEquil" => (:ρ, :e_int, :q_tot))
 get_nc(k) = joinpath(folder, "test_data_$(k).nc")
 get_data_to_append(k) = joinpath(@__DIR__, "test_data_$(k).csv")
 


### PR DESCRIPTION
This PR
 - Changes `PhaseEquil` outer constructor to `PhaseEquil_ρeq` (breaking for API changes)
 - Changes internal method `air_temperature_given_θρq` -> `air_temperature_given_ρθq`
 - Changes internal method `air_temperature_given_θpq` -> `air_temperature_given_pθq`
 - and changes the argument orders appropriately

This will allow us to avoid method ambiguities between `PhaseEquil` and `PhaseEquil_ρeq`.