### PR TITLE
Adding pressure as a variable in Thermodynamic state

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Climate Modeling Alliance"]
 version = "0.4.0"
 
 [deps]
+ArtifactWrappers = "a14bc488-3040-4b00-9dc1-f6467924858a"
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
@@ -14,7 +15,7 @@ RootSolvers = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
 [compat]
 CLIMAParameters = "0.1, 0.2"
 DocStringExtensions = "0.8.1"
+ExprTools = "0.1 - 0.1.3"
 KernelAbstractions = "0.5, 0.6"
 RootSolvers = "0.2"
-ExprTools = "0.1 - 0.1.3"
 julia = "1.4"

--- a/src/relations.jl
+++ b/src/relations.jl
@@ -110,19 +110,13 @@ function air_pressure(
     return gas_constant_air(param_set, q) * ρ * T
 end
 
+
 """
     air_pressure(ts::ThermodynamicState)
 
-The air pressure from the equation of state
-(ideal gas law), given a thermodynamic state `ts`.
+The air pressure, given a thermodynamic state `ts`.
 """
-air_pressure(ts::ThermodynamicState) = air_pressure(
-    ts.param_set,
-    air_temperature(ts),
-    air_density(ts),
-    PhasePartition(ts),
-)
-
+air_pressure(ts::ThermodynamicState) = ts.p
 
 """
     air_density(param_set, T, p[, q::PhasePartition])
@@ -1015,6 +1009,26 @@ function q_vap_saturation_from_pressure(
 end
 
 """
+    q_vap_saturation_from_partial_pressures(param_set, q_tot, p, p_v_sat)
+Compute the saturation specific humidity, given
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
+ - `q_tot` total water specific humidity,
+ - `p` air pressure,
+ - `p_v_sat` saturation vapor pressure
+"""
+function q_vap_saturation_from_partial_pressures(
+    param_set::APS,
+    q_tot::FT,
+    p::FT,
+    p_v_sat::FT,
+) where {FT <: Real}
+    _R_v::FT = R_v(param_set)
+    _R_d::FT = R_d(param_set)
+    return _R_d / _R_v * (1 - q_tot) * p_v_sat / (p - p_v_sat)
+end
+
+
+"""
     supersaturation(param_set, q, ρ, T, Liquid())
     supersaturation(param_set, q, ρ, T, Ice())
     supersaturation(ts, Ice())
@@ -1174,6 +1188,7 @@ liquid_fraction(ts::ThermodynamicState) = liquid_fraction(
     PhasePartition(ts),
 )
 
+
 """
     PhasePartition_equil(param_set, T, ρ, q_tot, phase_type)
 
@@ -1212,6 +1227,7 @@ PhasePartition_equil(ts::PhaseNonEquil) = PhasePartition_equil(
 )
 
 PhasePartition(ts::PhaseDry{FT}) where {FT <: Real} = q_pt_0(FT)
+
 PhasePartition(ts::PhaseEquil) = PhasePartition_equil(
     ts.param_set,
     air_temperature(ts),

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,4 @@
 [deps]
-ArtifactWrappers = "a14bc488-3040-4b00-9dc1-f6467924858a"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"


### PR DESCRIPTION
To accommodate the requirements for Anelastic, or even for SGS Anelastic, assumptions of the EDMF, we need to allow the Thermodynamic state to store the pressure variable given as input rather than computing it from the state variables when need. This will allow us to apps in either the reference (hydrostatic) pressure or the grid mean pressure make sure that this pressure is used consistently in that EDMF subdomain.