### PR TITLE
Better handle freezing in PhaseEquil_pθq constructor, add tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Thermodynamics"
 uuid = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 authors = ["Climate Modeling Alliance"]
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"

--- a/src/config_numerical_method.jl
+++ b/src/config_numerical_method.jl
@@ -188,3 +188,17 @@ function sa_numerical_method_pθq(
     T_2 = bound_upper_temperature(T_1, T_2)
     return RS.SecantMethod(T_1, T_2)
 end
+
+function sa_numerical_method_pθq(
+    ::Type{NM},
+    param_set::APS,
+    p::FT,
+    θ_liq_ice::FT,
+    q_tot::FT,
+    phase_type::Type{<:PhaseEquil},
+) where {FT, NM <: RS.NewtonsMethodAD}
+    T_min::FT = CPP.T_min(param_set)
+    air_temp(q) = air_temperature_given_pθq(param_set, p, θ_liq_ice, q)
+    T_init = max(T_min, air_temp(PhasePartition(q_tot))) # Assume all vapor
+    return RS.NewtonsMethodAD(T_init)
+end

--- a/src/states.jl
+++ b/src/states.jl
@@ -511,7 +511,6 @@ function PhaseEquil_pθq(
     temperature_tol === nothing && (temperature_tol = FT(1e-3))
     phase_type = PhaseEquil
     q_tot_safe = clamp(q_tot, FT(0), FT(1))
-    tol = RS.ResidualTolerance(temperature_tol)
     T = saturation_adjustment_given_pθq(
         sat_adjust_method,
         param_set,
@@ -520,7 +519,7 @@ function PhaseEquil_pθq(
         q_tot_safe,
         phase_type,
         maxiter,
-        tol,
+        temperature_tol,
     )
     q_pt = PhasePartition_equil_given_p(param_set, T, p, q_tot_safe, phase_type)
     ρ = air_density(param_set, T, p, q_pt)

--- a/test/data_tests.jl
+++ b/test/data_tests.jl
@@ -27,3 +27,56 @@ dycoms_dataset_path = get_data_folder(dycoms_dataset)
     ts = PhaseEquil_ρeq.(Ref(param_set), ρ, e_int, q_tot, 4)
     # ts = PhaseEquil_ρeq.(Ref(param_set), ρ, e_int, q_tot, 3) # Fails
 end
+
+@testset "pθq data-driven tests" begin
+    #! format: off
+    pθq_broken = [
+        # (; p = , θ_liq_ice = , q_tot = ),
+        # (; p = , θ_liq_ice = , q_tot = ),
+        # (; p = , θ_liq_ice = , q_tot = ),
+        # (; p = , θ_liq_ice = , q_tot = ),
+        # (; p = , θ_liq_ice = , q_tot = ),
+    ]
+    #! format: on
+    # config = (50, 1e-3, RootSolvers.RegulaFalsiMethod)
+    # config = (50, 1e-3, RootSolvers.NewtonMethodAD)
+    config = ()
+    if !isempty(pθq_broken)
+        p_arr = getproperty.(pθq_broken, :p)
+        θ_liq_ice_arr = getproperty.(pθq_broken, :θ_liq_ice)
+        q_tot_arr = getproperty.(pθq_broken, :q_tot)
+        for (p, θ_liq_ice, q_tot) in zip(p_arr, θ_liq_ice_arr, q_tot_arr)
+            @test_broken begin
+                ts = PhaseEquil_pθq(param_set, p, θ_liq_ice, q_tot, config...)
+                air_pressure(ts) == p
+            end
+        end
+    end
+
+    #! format: off
+    pθq = [
+        (; p = 82307.30319719888, θ_liq_ice = 296.7074342326652, q_tot = 0.01894019026929829,),
+        (; p = 88357.42589002676, θ_liq_ice = 296.7074342326652, q_tot = 0.01894019026929829,),
+        (; p = 81090.35731696963, θ_liq_ice = 296.7074342326652, q_tot = 0.01894019026929829,),
+        (; p = 75461.41343839701, θ_liq_ice = 296.7074342326652, q_tot = 0.01894019026929829,),
+        (; p = 71158.23329080557, θ_liq_ice = 296.7074342326652, q_tot = 0.01894019026929829,),
+        (; p = 68032.73180723468, θ_liq_ice = 296.7074342326652, q_tot = 0.01894019026929829,),
+        (; p = 59906.16044902247, θ_liq_ice = 296.7074342326652, q_tot = 0.01894019026929829,),
+        (; p = 51740.77281055945, θ_liq_ice = 296.7074342326652, q_tot = 0.01894019026929829,),
+        (; p = 50056.7894012541, θ_liq_ice = 296.7074342326652, q_tot = 0.01894019026929829,),
+        (; p = 48806.70567178993, θ_liq_ice = 296.7074342326652, q_tot = 0.01894019026929829,),
+        (; p = 27564.73889538213, θ_liq_ice = 296.7074342326652, q_tot = 0.01894019026929829,),
+    ]
+    #! format: on
+    if !isempty(pθq)
+        p_arr = getproperty.(pθq, :p)
+        θ_liq_ice_arr = getproperty.(pθq, :θ_liq_ice)
+        q_tot_arr = getproperty.(pθq, :q_tot)
+        for (p, θ_liq_ice, q_tot) in zip(p_arr, θ_liq_ice_arr, q_tot_arr)
+            @test begin
+                ts = PhaseEquil_pθq(param_set, p, θ_liq_ice, q_tot, config...)
+                air_pressure(ts) == p
+            end
+        end
+    end
+end


### PR DESCRIPTION
This PR handles freezing in the `PhaseEquil_pθq`, adds corresponding tests, and adds support for NewtonMethodAD in the `PhaseEquil_pθq`. We should now "converge" for some freezing temperatures which previously may have not converged.