### PR TITLE
Add more flexible phase partition in equilibrium

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Thermodynamics"
 uuid = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 authors = ["Climate Modeling Alliance"]
-version = "0.5.11"
+version = "0.6.0"
 
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
@@ -11,7 +11,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RootSolvers = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
 
 [compat]
-CLIMAParameters = "0.1, 0.2, 0.3, 0.4"
+CLIMAParameters = "0.4"
 DocStringExtensions = "0.8.1"
 KernelAbstractions = "0.7.2"
 RootSolvers = "0.2, 0.3"

--- a/gpuenv/Project.toml
+++ b/gpuenv/Project.toml
@@ -10,7 +10,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
-CLIMAParameters = "0.1, 0.2, 0.3, 0.4"
+CLIMAParameters = "0.4"
 CUDA = "3.5"
 CUDAKernels = "0.3"
 KernelAbstractions = "0.7.2"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -20,7 +20,7 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
-CLIMAParameters = "0.1, 0.2, 0.3, 0.4"
+CLIMAParameters = "0.4"
 KernelAbstractions = "0.7.2"
 RootSolvers = "0.2, 0.3"
 UnPack = "1.0"

--- a/test/relations.jl
+++ b/test/relations.jl
@@ -703,7 +703,7 @@ end
 
         @test count(air_temperature.(ts_lower) .== Ref(_T_freeze)) ≥ 217
         @test count(air_temperature.(ts_upper) .== Ref(_T_freeze)) ≥ 217
-        @test count(air_temperature.(ts_mid) .== Ref(_T_freeze)) ≥ 1395
+        @test count(air_temperature.(ts_mid) .== Ref(_T_freeze)) ≥ 1392
         # we should do this instead, but we're failing because some inputs are bad
         # E.g. p ~ 110_000 Pa, q_tot ~ 0.16, which results in negative θ_liq_ice
         # This means that we should probably update our tested profiles.


### PR DESCRIPTION
As mentioned in #87 I would like to have a phase partition function similar to what is used in PyCLES. 

I know that in the end we will be using a non-equilibrium formulation. But I think in the mean time, it would be good to assume the same phase partition in LES and single column models.