### PR TITLE
Synchronize compat entries

### DIFF
--- a/gpuenv/Project.toml
+++ b/gpuenv/Project.toml
@@ -10,10 +10,10 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
-CLIMAParameters = "0.3"
+CLIMAParameters = "0.1, 0.2, 0.3, 0.4"
 CUDA = "3.5"
 CUDAKernels = "0.3"
 KernelAbstractions = "0.7.2"
-RootSolvers = "0.2"
+RootSolvers = "0.2, 0.3"
 UnPack = "1.0"
 julia = "1.7"


### PR DESCRIPTION
Applying `import CompatDevTools; CompatDevTools.synchronize_compats(".")` revealed several inconsistent compat entries. This PR fixes them. I haven't updated the required julia version because the only dependency that now requires 1.7 is KernelAbstractions.jl, which is only needed for CPU/GPU error printing. So, I've left it alone for now.