### PR TITLE
Remove param_set cache from thermo states

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Thermodynamics"
 uuid = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 authors = ["Climate Modeling Alliance"]
-version = "0.6.0"
+version = "0.7.0"
 
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -72,8 +72,8 @@ we've established a thermodynamic state, we can call [Thermodynamic state
 methods](@ref) that support thermodynamic states:
 
 ```julia
-T = air_temperature(ts);
-q = PhasePartition(ts);
+T = air_temperature(param_set, ts);
+q = PhasePartition(param_set, ts);
 ```
 
 No changes to the "right-hand sides" of the dynamical equations are needed
@@ -90,7 +90,7 @@ q_tot          = ...
 (u, v, w)    = ...
 e_kin           = 0.5 * (u^2 + v^2 + w^2)
 
-e_tot        = total_energy(e_kin, geopotential, T, q_tot)
+e_tot        = total_energy(param_set, e_kin, geopotential, T, q_tot)
 
 do timestep   # timestepping loop
 
@@ -103,9 +103,9 @@ do timestep   # timestepping loop
 
   # compute temperature, pressure and condensate specific humidities,
   ts = PhaseEquil_ρeq(param_set, ρ, e_int, q_tot);
-  T = air_temperature(ts);
-  q = PhasePartition(ts);
-  p = air_pressure(ts);
+  T = air_temperature(param_set, ts);
+  q = PhasePartition(param_set, ts);
+  p = air_pressure(param_set, ts);
 
 end
 ```
@@ -119,6 +119,6 @@ non-equilibrium moist thermodynamic state:
 ```julia
 q_tot, q_liq, q_ice = ...
 ts = PhaseNonEquil(param_set, e_int, ρ, PhasePartition(q_tot, q_liq, q_ice));
-T = air_temperature(ts);
-p = air_pressure(ts);
+T = air_temperature(param_set, ts);
+p = air_pressure(param_set, ts);
 ```

--- a/src/TestedProfiles.jl
+++ b/src/TestedProfiles.jl
@@ -162,7 +162,7 @@ end
 Returns a `ProfileSet` used to test dry thermodynamic states.
 """
 function PhaseDryProfiles(param_set::APS, ::Type{ArrayType}) where {ArrayType}
-    phase_type = TD.PhaseDry{eltype(ArrayType), typeof(param_set)}
+    phase_type = TD.PhaseDry{eltype(ArrayType)}
 
     z_range, relative_sat, T_surface, T_min = input_config(ArrayType)
     z, T_virt, p, RS =
@@ -222,7 +222,7 @@ end
 Returns a `ProfileSet` used to test moist states in thermodynamic equilibrium.
 """
 function PhaseEquilProfiles(param_set::APS, ::Type{ArrayType}) where {ArrayType}
-    phase_type = TD.PhaseEquil{eltype(ArrayType), typeof(param_set)}
+    phase_type = TD.PhaseEquil{eltype(ArrayType)}
 
     # Prescribe z_range, relative_sat, T_surface, T_min
     z_range, relative_sat, T_surface, T_min = input_config(ArrayType)

--- a/src/relations.jl
+++ b/src/relations.jl
@@ -80,15 +80,15 @@ gas_constant_air(param_set::APS, ::Type{FT}) where {FT} =
     gas_constant_air(param_set, q_pt_0(FT))
 
 """
-    gas_constant_air(ts::ThermodynamicState)
+    gas_constant_air(param_set::APS, ts::ThermodynamicState)
 
 The specific gas constant of moist air given
 a thermodynamic state `ts`.
 """
-gas_constant_air(ts::ThermodynamicState) =
-    gas_constant_air(ts.param_set, PhasePartition(ts))
-gas_constant_air(ts::AbstractPhaseDry{FT}) where {FT <: Real} =
-    FT(ICP.R_d(ts.param_set))
+gas_constant_air(param_set::APS, ts::ThermodynamicState) =
+    gas_constant_air(param_set, PhasePartition(param_set, ts))
+gas_constant_air(param_set::APS, ts::AbstractPhaseDry{FT}) where {FT <: Real} =
+    FT(ICP.R_d(param_set))
 
 
 """
@@ -113,19 +113,19 @@ function air_pressure(
 end
 
 """
-    air_pressure(ts::ThermodynamicState)
+    air_pressure(param_set::APS, ts::ThermodynamicState)
 
 The air pressure from the equation of state
 (ideal gas law), given a thermodynamic state `ts`.
 """
-air_pressure(ts::ThermodynamicState) = air_pressure(
-    ts.param_set,
-    air_temperature(ts),
-    air_density(ts),
-    PhasePartition(ts),
+air_pressure(param_set::APS, ts::ThermodynamicState) = air_pressure(
+    param_set,
+    air_temperature(param_set, ts),
+    air_density(param_set, ts),
+    PhasePartition(param_set, ts),
 )
 
-air_pressure(ts::PhaseEquil) = ts.p
+air_pressure(param_set::APS, ts::PhaseEquil) = ts.p
 
 """
     air_density(param_set, T, p[, q::PhasePartition])
@@ -149,21 +149,22 @@ function air_density(
 end
 
 """
-    air_density(ts::ThermodynamicState)
+    air_density(param_set::APS, ts::ThermodynamicState)
 
 The (moist-)air density, given a thermodynamic state `ts`.
 """
-air_density(ts::ThermodynamicState) = ts.ρ
+air_density(param_set::APS, ts::ThermodynamicState) = ts.ρ
 
 """
-    specific_volume(ts::ThermodynamicState)
+    specific_volume(param_set::APS, ts::ThermodynamicState)
 
 The (moist-)air specific volume, given a thermodynamic state `ts`.
 """
-specific_volume(ts::ThermodynamicState) = 1 / air_density(ts)
+specific_volume(param_set::APS, ts::ThermodynamicState) =
+    1 / air_density(param_set, ts)
 
 """
-    total_specific_humidity(ts::ThermodynamicState)
+    total_specific_humidity(param_set::APS, ts::ThermodynamicState)
     total_specific_humidity(param_set, T, p, relative_humidity)
 
 Total specific humidity given
@@ -174,12 +175,13 @@ or
  - `p` pressure
  - `relative_humidity` relative humidity (can exceed 1 when there is super saturation/condensate)
 """
-total_specific_humidity(ts::ThermodynamicState) = ts.q_tot
-total_specific_humidity(ts::AbstractPhaseDry{FT}) where {FT} = FT(0)
-total_specific_humidity(ts::AbstractPhaseNonEquil) = ts.q.tot
+total_specific_humidity(param_set::APS, ts::ThermodynamicState) = ts.q_tot
+total_specific_humidity(param_set::APS, ts::AbstractPhaseDry{FT}) where {FT} =
+    FT(0)
+total_specific_humidity(param_set::APS, ts::AbstractPhaseNonEquil) = ts.q.tot
 
 """
-    liquid_specific_humidity(ts::ThermodynamicState)
+    liquid_specific_humidity(param_set::APS, ts::ThermodynamicState)
     liquid_specific_humidity(q::PhasePartition)
 
 Liquid specific humidity given
@@ -188,12 +190,14 @@ or
  - `q` a `PhasePartition`
 """
 liquid_specific_humidity(q::PhasePartition) = q.liq
-liquid_specific_humidity(ts::ThermodynamicState) = PhasePartition(ts).liq
-liquid_specific_humidity(ts::AbstractPhaseDry{FT}) where {FT} = FT(0)
-liquid_specific_humidity(ts::AbstractPhaseNonEquil) = ts.q.liq
+liquid_specific_humidity(param_set::APS, ts::ThermodynamicState) =
+    PhasePartition(param_set, ts).liq
+liquid_specific_humidity(param_set::APS, ts::AbstractPhaseDry{FT}) where {FT} =
+    FT(0)
+liquid_specific_humidity(param_set::APS, ts::AbstractPhaseNonEquil) = ts.q.liq
 
 """
-    ice_specific_humidity(ts::ThermodynamicState)
+    ice_specific_humidity(param_set::APS, ts::ThermodynamicState)
     ice_specific_humidity(q::PhasePartition)
 
 Ice specific humidity given
@@ -202,9 +206,11 @@ or
  - `q` a `PhasePartition`
 """
 ice_specific_humidity(q::PhasePartition) = q.ice
-ice_specific_humidity(ts::ThermodynamicState) = PhasePartition(ts).ice
-ice_specific_humidity(ts::AbstractPhaseDry{FT}) where {FT} = FT(0)
-ice_specific_humidity(ts::AbstractPhaseNonEquil) = ts.q.ice
+ice_specific_humidity(param_set::APS, ts::ThermodynamicState) =
+    PhasePartition(param_set, ts).ice
+ice_specific_humidity(param_set::APS, ts::AbstractPhaseDry{FT}) where {FT} =
+    FT(0)
+ice_specific_humidity(param_set::APS, ts::AbstractPhaseNonEquil) = ts.q.ice
 
 """
     vapor_specific_humidity(q::PhasePartition{FT})
@@ -212,8 +218,8 @@ ice_specific_humidity(ts::AbstractPhaseNonEquil) = ts.q.ice
 The vapor specific humidity, given a `PhasePartition` `q`.
 """
 vapor_specific_humidity(q::PhasePartition) = max(0, q.tot - q.liq - q.ice)
-vapor_specific_humidity(ts::ThermodynamicState) =
-    vapor_specific_humidity(PhasePartition(ts))
+vapor_specific_humidity(param_set::APS, ts::ThermodynamicState) =
+    vapor_specific_humidity(PhasePartition(param_set, ts))
 
 """
     cp_m(param_set, q::PhasePartition)
@@ -237,12 +243,14 @@ cp_m(param_set::APS, ::Type{FT}) where {FT <: Real} =
     cp_m(param_set, q_pt_0(FT))
 
 """
-    cp_m(ts::ThermodynamicState)
+    cp_m(param_set::APS, ts::ThermodynamicState)
 
 The isobaric specific heat capacity of moist air, given a thermodynamic state `ts`.
 """
-cp_m(ts::ThermodynamicState) = cp_m(ts.param_set, PhasePartition(ts))
-cp_m(ts::AbstractPhaseDry{FT}) where {FT <: Real} = FT(ICP.cp_d(ts.param_set))
+cp_m(param_set::APS, ts::ThermodynamicState) =
+    cp_m(param_set, PhasePartition(param_set, ts))
+cp_m(param_set::APS, ts::AbstractPhaseDry{FT}) where {FT <: Real} =
+    FT(ICP.cp_d(param_set))
 
 """
     cv_m(param_set, q::PhasePartition)
@@ -266,12 +274,14 @@ cv_m(param_set::APS, ::Type{FT}) where {FT <: Real} =
     cv_m(param_set, q_pt_0(FT))
 
 """
-    cv_m(ts::ThermodynamicState)
+    cv_m(param_set::APS, ts::ThermodynamicState)
 
 The isochoric specific heat capacity of moist air, given a thermodynamic state `ts`.
 """
-cv_m(ts::ThermodynamicState) = cv_m(ts.param_set, PhasePartition(ts))
-cv_m(ts::AbstractPhaseDry{FT}) where {FT <: Real} = FT(ICP.cv_d(ts.param_set))
+cv_m(param_set::APS, ts::ThermodynamicState) =
+    cv_m(param_set, PhasePartition(param_set, ts))
+cv_m(param_set::APS, ts::AbstractPhaseDry{FT}) where {FT <: Real} =
+    FT(ICP.cv_d(param_set))
 
 
 """
@@ -296,7 +306,7 @@ function gas_constants(param_set::APS, q::PhasePartition{FT}) where {FT <: Real}
 end
 
 """
-    (R_m, cp_m, cv_m, γ_m) = gas_constants(ts::ThermodynamicState)
+    (R_m, cp_m, cv_m, γ_m) = gas_constants(param_set::APS, ts::ThermodynamicState)
 
 Wrapper to compute all gas constants at once, given a thermodynamic state `ts`.
 
@@ -307,8 +317,8 @@ The function returns a tuple of
  - `γ_m = cp_m/cv_m`
 
 """
-gas_constants(ts::ThermodynamicState) =
-    gas_constants(ts.param_set, PhasePartition(ts))
+gas_constants(param_set::APS, ts::ThermodynamicState) =
+    gas_constants(param_set, PhasePartition(param_set, ts))
 
 """
     air_temperature(param_set, e_int, q::PhasePartition)
@@ -335,13 +345,16 @@ function air_temperature(
 end
 
 """
-    air_temperature(ts::ThermodynamicState)
+    air_temperature(param_set::APS, ts::ThermodynamicState)
 
 The air temperature, given a thermodynamic state `ts`.
 """
-air_temperature(ts::ThermodynamicState) =
-    air_temperature(ts.param_set, internal_energy(ts), PhasePartition(ts))
-air_temperature(ts::AbstractPhaseEquil) = ts.T
+air_temperature(param_set::APS, ts::ThermodynamicState) = air_temperature(
+    param_set,
+    internal_energy(param_set, ts),
+    PhasePartition(param_set, ts),
+)
+air_temperature(param_set::APS, ts::AbstractPhaseEquil) = ts.T
 
 """
     air_temperature_from_ideal_gas_law(param_set, p, ρ, q::PhasePartition)
@@ -387,11 +400,11 @@ function internal_energy(
 end
 
 """
-    internal_energy(ts::ThermodynamicState)
+    internal_energy(param_set::APS, ts::ThermodynamicState)
 
 The internal energy per unit mass, given a thermodynamic state `ts`.
 """
-internal_energy(ts::ThermodynamicState) = ts.e_int
+internal_energy(param_set::APS, ts::ThermodynamicState) = ts.e_int
 
 """
     internal_energy(ρ::FT, ρe::FT, ρu::AbstractVector{FT}, e_pot::FT)
@@ -432,12 +445,12 @@ function internal_energy_dry(param_set::APS, T::FT) where {FT <: Real}
 end
 
 """
-    internal_energy_dry(ts::ThermodynamicState)
+    internal_energy_dry(param_set::APS, ts::ThermodynamicState)
 
 The the dry air internal energy, given a thermodynamic state `ts`.
 """
-internal_energy_dry(ts::ThermodynamicState) =
-    internal_energy_dry(ts.param_set, air_temperature(ts))
+internal_energy_dry(param_set::APS, ts::ThermodynamicState) =
+    internal_energy_dry(param_set, air_temperature(param_set, ts))
 
 """
     internal_energy_vapor(param_set, T)
@@ -456,12 +469,12 @@ function internal_energy_vapor(param_set::APS, T::FT) where {FT <: Real}
 end
 
 """
-    internal_energy_vapor(ts::ThermodynamicState)
+    internal_energy_vapor(param_set::APS, ts::ThermodynamicState)
 
 The the water vapor internal energy, given a thermodynamic state `ts`.
 """
-internal_energy_vapor(ts::ThermodynamicState) =
-    internal_energy_vapor(ts.param_set, air_temperature(ts))
+internal_energy_vapor(param_set::APS, ts::ThermodynamicState) =
+    internal_energy_vapor(param_set, air_temperature(param_set, ts))
 
 """
     internal_energy_liquid(param_set, T)
@@ -479,12 +492,12 @@ function internal_energy_liquid(param_set::APS, T::FT) where {FT <: Real}
 end
 
 """
-    internal_energy_liquid(ts::ThermodynamicState)
+    internal_energy_liquid(param_set::APS, ts::ThermodynamicState)
 
 The the liquid water internal energy, given a thermodynamic state `ts`.
 """
-internal_energy_liquid(ts::ThermodynamicState) =
-    internal_energy_liquid(ts.param_set, air_temperature(ts))
+internal_energy_liquid(param_set::APS, ts::ThermodynamicState) =
+    internal_energy_liquid(param_set, air_temperature(param_set, ts))
 
 """
     internal_energy_ice(param_set, T)
@@ -503,12 +516,12 @@ function internal_energy_ice(param_set::APS, T::FT) where {FT <: Real}
 end
 
 """
-    internal_energy_ice(ts::ThermodynamicState)
+    internal_energy_ice(param_set::APS, ts::ThermodynamicState)
 
 The the ice internal energy, given a thermodynamic state `ts`.
 """
-internal_energy_ice(ts::ThermodynamicState) =
-    internal_energy_ice(ts.param_set, air_temperature(ts))
+internal_energy_ice(param_set::APS, ts::ThermodynamicState) =
+    internal_energy_ice(param_set, air_temperature(param_set, ts))
 
 """
     internal_energy_sat(param_set, T, ρ, q_tot, phase_type)
@@ -536,19 +549,20 @@ function internal_energy_sat(
 end
 
 """
-    internal_energy_sat(ts::ThermodynamicState)
+    internal_energy_sat(param_set::APS, ts::ThermodynamicState)
 
 The internal energy per unit mass in
 thermodynamic equilibrium at saturation,
 given a thermodynamic state `ts`.
 """
-internal_energy_sat(ts::ThermodynamicState) = internal_energy_sat(
-    ts.param_set,
-    air_temperature(ts),
-    air_density(ts),
-    total_specific_humidity(ts),
-    typeof(ts),
-)
+internal_energy_sat(param_set::APS, ts::ThermodynamicState) =
+    internal_energy_sat(
+        param_set,
+        air_temperature(param_set, ts),
+        air_density(param_set, ts),
+        total_specific_humidity(param_set, ts),
+        typeof(ts),
+    )
 
 
 """
@@ -575,17 +589,18 @@ function total_energy(
 end
 
 """
-    total_energy(e_kin, e_pot, ts::ThermodynamicState)
+    total_energy(param_set::APS, ts::ThermodynamicState, e_kin, e_pot)
 
 The total energy per unit mass
 given a thermodynamic state `ts`.
 """
 function total_energy(
+    param_set::APS,
+    ts::ThermodynamicState{FT},
     e_kin::FT,
     e_pot::FT,
-    ts::ThermodynamicState{FT},
 ) where {FT <: Real}
-    return internal_energy(ts) + e_kin + e_pot
+    return internal_energy(param_set, ts) + e_kin + e_pot
 end
 
 """
@@ -633,12 +648,15 @@ function soundspeed_air(
 end
 
 """
-    soundspeed_air(ts::ThermodynamicState)
+    soundspeed_air(param_set::APS, ts::ThermodynamicState)
 
 The speed of sound in unstratified air given a thermodynamic state `ts`.
 """
-soundspeed_air(ts::ThermodynamicState) =
-    soundspeed_air(ts.param_set, air_temperature(ts), PhasePartition(ts))
+soundspeed_air(param_set::APS, ts::ThermodynamicState) = soundspeed_air(
+    param_set,
+    air_temperature(param_set, ts),
+    PhasePartition(param_set, ts),
+)
 
 
 """
@@ -656,13 +674,13 @@ function latent_heat_vapor(param_set::APS, T::FT) where {FT <: Real}
 end
 
 """
-    latent_heat_vapor(ts::ThermodynamicState)
+    latent_heat_vapor(param_set::APS, ts::ThermodynamicState)
 
 The specific latent heat of vaporization
 given a thermodynamic state `ts`.
 """
-latent_heat_vapor(ts::ThermodynamicState) =
-    latent_heat_vapor(ts.param_set, air_temperature(ts))
+latent_heat_vapor(param_set::APS, ts::ThermodynamicState) =
+    latent_heat_vapor(param_set, air_temperature(param_set, ts))
 
 """
     latent_heat_sublim(param_set, T::FT) where {FT<:Real}
@@ -679,13 +697,13 @@ function latent_heat_sublim(param_set::APS, T::FT) where {FT <: Real}
 end
 
 """
-    latent_heat_sublim(ts::ThermodynamicState)
+    latent_heat_sublim(param_set::APS, ts::ThermodynamicState)
 
 The specific latent heat of sublimation
 given a thermodynamic state `ts`.
 """
-latent_heat_sublim(ts::ThermodynamicState) =
-    latent_heat_sublim(ts.param_set, air_temperature(ts))
+latent_heat_sublim(param_set::APS, ts::ThermodynamicState) =
+    latent_heat_sublim(param_set, air_temperature(param_set, ts))
 
 """
     latent_heat_fusion(param_set, T::FT) where {FT<:Real}
@@ -702,13 +720,13 @@ function latent_heat_fusion(param_set::APS, T::FT) where {FT <: Real}
 end
 
 """
-    latent_heat_fusion(ts::ThermodynamicState)
+    latent_heat_fusion(param_set::APS, ts::ThermodynamicState)
 
 The specific latent heat of fusion
 given a thermodynamic state `ts`.
 """
-latent_heat_fusion(ts::ThermodynamicState) =
-    latent_heat_fusion(ts.param_set, air_temperature(ts))
+latent_heat_fusion(param_set::APS, ts::ThermodynamicState) =
+    latent_heat_fusion(param_set, air_temperature(param_set, ts))
 
 """
     latent_heat_generic(param_set, T::FT, LH_0::FT, Δcp::FT) where {FT<:Real}
@@ -808,15 +826,16 @@ function saturation_vapor_pressure(
 end
 
 function saturation_vapor_pressure(
+    param_set::APS,
     ts::ThermodynamicState{FT},
     ::Liquid,
 ) where {FT <: Real}
-    LH_v0::FT = ICP.LH_v0(ts.param_set)
-    cp_v::FT = ICP.cp_v(ts.param_set)
-    cp_l::FT = ICP.cp_l(ts.param_set)
+    LH_v0::FT = ICP.LH_v0(param_set)
+    cp_v::FT = ICP.cp_v(param_set)
+    cp_l::FT = ICP.cp_l(param_set)
     return saturation_vapor_pressure(
-        ts.param_set,
-        air_temperature(ts),
+        param_set,
+        air_temperature(param_set, ts),
         LH_v0,
         cp_v - cp_l,
     )
@@ -835,15 +854,16 @@ function saturation_vapor_pressure(
 end
 
 function saturation_vapor_pressure(
+    param_set::APS,
     ts::ThermodynamicState{FT},
     ::Ice,
 ) where {FT <: Real}
-    LH_s0::FT = ICP.LH_s0(ts.param_set)
-    cp_v::FT = ICP.cp_v(ts.param_set)
-    cp_i::FT = ICP.cp_i(ts.param_set)
+    LH_s0::FT = ICP.LH_s0(param_set)
+    cp_v::FT = ICP.cp_v(param_set)
+    cp_i::FT = ICP.cp_i(param_set)
     return saturation_vapor_pressure(
-        ts.param_set,
-        air_temperature(ts),
+        param_set,
+        air_temperature(param_set, ts),
         LH_s0,
         cp_v - cp_i,
     )
@@ -959,43 +979,45 @@ function q_vap_saturation(
 end
 
 """
-    q_vap_saturation(ts::ThermodynamicState)
+    q_vap_saturation(param_set::APS, ts::ThermodynamicState)
 
 Compute the saturation specific humidity, given a thermodynamic state `ts`.
 """
-q_vap_saturation(ts::ThermodynamicState) = q_vap_saturation(
-    ts.param_set,
-    air_temperature(ts),
-    air_density(ts),
+q_vap_saturation(param_set::APS, ts::ThermodynamicState) = q_vap_saturation(
+    param_set,
+    air_temperature(param_set, ts),
+    air_density(param_set, ts),
     typeof(ts),
-    PhasePartition(ts),
+    PhasePartition(param_set, ts),
 )
 
 """
-    q_vap_saturation_liquid(ts::ThermodynamicState)
+    q_vap_saturation_liquid(param_set::APS, ts::ThermodynamicState)
 
 Compute the saturation specific humidity over liquid,
 given a thermodynamic state `ts`.
 """
-q_vap_saturation_liquid(ts::ThermodynamicState) = q_vap_saturation_generic(
-    ts.param_set,
-    air_temperature(ts),
-    air_density(ts),
-    Liquid(),
-)
+q_vap_saturation_liquid(param_set::APS, ts::ThermodynamicState) =
+    q_vap_saturation_generic(
+        param_set,
+        air_temperature(param_set, ts),
+        air_density(param_set, ts),
+        Liquid(),
+    )
 
 """
-    q_vap_saturation_ice(ts::ThermodynamicState)
+    q_vap_saturation_ice(param_set::APS, ts::ThermodynamicState)
 
 Compute the saturation specific humidity over ice,
 given a thermodynamic state `ts`.
 """
-q_vap_saturation_ice(ts::ThermodynamicState) = q_vap_saturation_generic(
-    ts.param_set,
-    air_temperature(ts),
-    air_density(ts),
-    Ice(),
-)
+q_vap_saturation_ice(param_set::APS, ts::ThermodynamicState) =
+    q_vap_saturation_generic(
+        param_set,
+        air_temperature(param_set, ts),
+        air_density(param_set, ts),
+        Ice(),
+    )
 
 """
     q_vap_saturation_from_density(param_set, T, ρ, p_v_sat)
@@ -1081,13 +1103,14 @@ function supersaturation(
 
     return q_vap / q_sat - FT(1)
 end
-supersaturation(ts::ThermodynamicState, phase::Phase) = supersaturation(
-    ts.param_set,
-    PhasePartition(ts),
-    air_density(ts),
-    air_temperature(ts),
-    phase,
-)
+supersaturation(param_set::APS, ts::ThermodynamicState, phase::Phase) =
+    supersaturation(
+        param_set,
+        PhasePartition(param_set, ts),
+        air_density(param_set, ts),
+        air_temperature(param_set, ts),
+        phase,
+    )
 
 """
     saturation_excess(param_set, T, ρ, phase_type, q::PhasePartition)
@@ -1115,38 +1138,40 @@ function saturation_excess(
 end
 
 """
-    saturation_excess(ts::ThermodynamicState)
+    saturation_excess(param_set::APS, ts::ThermodynamicState)
 
 Compute the saturation excess in equilibrium,
 given a thermodynamic state `ts`.
 """
-saturation_excess(ts::ThermodynamicState) = saturation_excess(
-    ts.param_set,
-    air_temperature(ts),
-    air_density(ts),
+saturation_excess(param_set::APS, ts::ThermodynamicState) = saturation_excess(
+    param_set,
+    air_temperature(param_set, ts),
+    air_density(param_set, ts),
     typeof(ts),
-    PhasePartition(ts),
+    PhasePartition(param_set, ts),
 )
 
 """
     condensate(q::PhasePartition{FT})
-    condensate(ts::ThermodynamicState)
+    condensate(param_set::APS, ts::ThermodynamicState)
 
 Condensate of the phase partition.
 """
 condensate(q::PhasePartition) = q.liq + q.ice
-condensate(ts::ThermodynamicState) = condensate(PhasePartition(ts))
+condensate(param_set::APS, ts::ThermodynamicState) =
+    condensate(PhasePartition(param_set, ts))
 
 """
     has_condensate(q::PhasePartition{FT})
-    has_condensate(ts::ThermodynamicState)
+    has_condensate(param_set::APS, ts::ThermodynamicState)
 
 Bool indicating if condensate exists in the phase
 partition
 """
 has_condensate(q_c::FT) where {FT} = q_c > eps(FT)
 has_condensate(q::PhasePartition) = has_condensate(condensate(q))
-has_condensate(ts::ThermodynamicState) = has_condensate(PhasePartition(ts))
+has_condensate(param_set::APS, ts::ThermodynamicState) =
+    has_condensate(PhasePartition(param_set, ts))
 
 
 """
@@ -1199,15 +1224,15 @@ function liquid_fraction(
 end
 
 """
-    liquid_fraction(ts::ThermodynamicState)
+    liquid_fraction(param_set::APS, ts::ThermodynamicState)
 
 The fraction of condensate that is liquid given a thermodynamic state `ts`.
 """
-liquid_fraction(ts::ThermodynamicState) = liquid_fraction(
-    ts.param_set,
-    air_temperature(ts),
+liquid_fraction(param_set::APS, ts::ThermodynamicState) = liquid_fraction(
+    param_set,
+    air_temperature(param_set, ts),
     typeof(ts),
-    PhasePartition(ts),
+    PhasePartition(param_set, ts),
 )
 
 """
@@ -1239,13 +1264,14 @@ function PhasePartition_equil(
     return PhasePartition(q_tot, q_liq, q_ice)
 end
 
-PhasePartition_equil(ts::AbstractPhaseNonEquil) = PhasePartition_equil(
-    ts.param_set,
-    air_temperature(ts),
-    air_density(ts),
-    total_specific_humidity(ts),
-    typeof(ts),
-)
+PhasePartition_equil(param_set::APS, ts::AbstractPhaseNonEquil) =
+    PhasePartition_equil(
+        param_set,
+        air_temperature(param_set, ts),
+        air_density(param_set, ts),
+        total_specific_humidity(param_set, ts),
+        typeof(ts),
+    )
 
 
 """
@@ -1275,15 +1301,16 @@ function PhasePartition_equil_given_p(
     return PhasePartition(q_tot, q_liq, q_ice)
 end
 
-PhasePartition(ts::AbstractPhaseDry{FT}) where {FT <: Real} = q_pt_0(FT)
-PhasePartition(ts::AbstractPhaseEquil) = PhasePartition_equil(
-    ts.param_set,
-    air_temperature(ts),
-    air_density(ts),
-    total_specific_humidity(ts),
+PhasePartition(param_set::APS, ts::AbstractPhaseDry{FT}) where {FT <: Real} =
+    q_pt_0(FT)
+PhasePartition(param_set::APS, ts::AbstractPhaseEquil) = PhasePartition_equil(
+    param_set,
+    air_temperature(param_set, ts),
+    air_density(param_set, ts),
+    total_specific_humidity(param_set, ts),
     typeof(ts),
 )
-PhasePartition(ts::AbstractPhaseNonEquil) = ts.q
+PhasePartition(param_set::APS, ts::AbstractPhaseNonEquil) = ts.q
 
 function ∂e_int_∂T(
     param_set::APS,
@@ -1885,16 +1912,16 @@ function liquid_ice_pottemp(
 end
 
 """
-    liquid_ice_pottemp(ts::ThermodynamicState)
+    liquid_ice_pottemp(param_set::APS, ts::ThermodynamicState)
 
 The liquid-ice potential temperature,
 given a thermodynamic state `ts`.
 """
-liquid_ice_pottemp(ts::ThermodynamicState) = liquid_ice_pottemp(
-    ts.param_set,
-    air_temperature(ts),
-    air_density(ts),
-    PhasePartition(ts),
+liquid_ice_pottemp(param_set::APS, ts::ThermodynamicState) = liquid_ice_pottemp(
+    param_set,
+    air_temperature(param_set, ts),
+    air_density(param_set, ts),
+    PhasePartition(param_set, ts),
 )
 
 """
@@ -1938,15 +1965,15 @@ function dry_pottemp_given_pressure(
 end
 
 """
-    dry_pottemp(ts::ThermodynamicState)
+    dry_pottemp(param_set::APS, ts::ThermodynamicState)
 
 The dry potential temperature, given a thermodynamic state `ts`.
 """
-dry_pottemp(ts::ThermodynamicState) = dry_pottemp(
-    ts.param_set,
-    air_temperature(ts),
-    air_density(ts),
-    PhasePartition(ts),
+dry_pottemp(param_set::APS, ts::ThermodynamicState) = dry_pottemp(
+    param_set,
+    air_temperature(param_set, ts),
+    air_density(param_set, ts),
+    PhasePartition(param_set, ts),
 )
 
 function virt_temp_from_RH(
@@ -2161,16 +2188,16 @@ function virtual_pottemp(
 end
 
 """
-    virtual_pottemp(ts::ThermodynamicState)
+    virtual_pottemp(param_set::APS, ts::ThermodynamicState)
 
 The virtual potential temperature,
 given a thermodynamic state `ts`.
 """
-virtual_pottemp(ts::ThermodynamicState) = virtual_pottemp(
-    ts.param_set,
-    air_temperature(ts),
-    air_density(ts),
-    PhasePartition(ts),
+virtual_pottemp(param_set::APS, ts::ThermodynamicState) = virtual_pottemp(
+    param_set,
+    air_temperature(param_set, ts),
+    air_density(param_set, ts),
+    PhasePartition(param_set, ts),
 )
 
 """
@@ -2195,17 +2222,18 @@ function virtual_temperature(
 end
 
 """
-    virtual_temperature(ts::ThermodynamicState)
+    virtual_temperature(param_set::APS, ts::ThermodynamicState)
 
 The virtual temperature,
 given a thermodynamic state `ts`.
 """
-virtual_temperature(ts::ThermodynamicState) = virtual_temperature(
-    ts.param_set,
-    air_temperature(ts),
-    air_density(ts),
-    PhasePartition(ts),
-)
+virtual_temperature(param_set::APS, ts::ThermodynamicState) =
+    virtual_temperature(
+        param_set,
+        air_temperature(param_set, ts),
+        air_density(param_set, ts),
+        PhasePartition(param_set, ts),
+    )
 
 
 """
@@ -2258,17 +2286,18 @@ function liquid_ice_pottemp_sat(
 end
 
 """
-    liquid_ice_pottemp_sat(ts::ThermodynamicState)
+    liquid_ice_pottemp_sat(param_set::APS, ts::ThermodynamicState)
 
 The liquid potential temperature given a thermodynamic state `ts`.
 """
-liquid_ice_pottemp_sat(ts::ThermodynamicState) = liquid_ice_pottemp_sat(
-    ts.param_set,
-    air_temperature(ts),
-    air_density(ts),
-    typeof(ts),
-    PhasePartition(ts),
-)
+liquid_ice_pottemp_sat(param_set::APS, ts::ThermodynamicState) =
+    liquid_ice_pottemp_sat(
+        param_set,
+        air_temperature(param_set, ts),
+        air_density(param_set, ts),
+        typeof(ts),
+        PhasePartition(param_set, ts),
+    )
 
 """
     exner_given_pressure(param_set, p[, q::PhasePartition])
@@ -2312,15 +2341,15 @@ function exner(
 end
 
 """
-    exner(ts::ThermodynamicState)
+    exner(param_set::APS, ts::ThermodynamicState)
 
 The Exner function, given a thermodynamic state `ts`.
 """
-exner(ts::ThermodynamicState) = exner(
-    ts.param_set,
-    air_temperature(ts),
-    air_density(ts),
-    PhasePartition(ts),
+exner(param_set::APS, ts::ThermodynamicState) = exner(
+    param_set,
+    air_temperature(param_set, ts),
+    air_density(param_set, ts),
+    PhasePartition(param_set, ts),
 )
 
 """
@@ -2352,14 +2381,15 @@ function mixing_ratios(q::PhasePartition{FT}) where {FT <: Real}
 end
 
 """
-    mixing_ratios(ts::ThermodynamicState)
+    mixing_ratios(param_set::APS, ts::ThermodynamicState)
 
 Mixing ratios stored, in a phase partition, for
  - total specific humidity
  - liquid specific humidity
  - ice specific humidity
 """
-mixing_ratios(ts::ThermodynamicState) = mixing_ratios(PhasePartition(ts))
+mixing_ratios(param_set::APS, ts::ThermodynamicState) =
+    mixing_ratios(PhasePartition(param_set, ts))
 
 """
     vol_vapor_mixing_ratio(param_set, q::PhasePartition)
@@ -2402,20 +2432,23 @@ function relative_humidity(
 end
 
 """
-    relative_humidity(ts::ThermodynamicState)
+    relative_humidity(param_set::APS, ts::ThermodynamicState)
 
 The relative humidity, given a thermodynamic state `ts`.
 """
-relative_humidity(ts::ThermodynamicState{FT}) where {FT <: Real} =
-    relative_humidity(
-        ts.param_set,
-        air_temperature(ts),
-        air_pressure(ts),
-        typeof(ts),
-        PhasePartition(ts),
-    )
+relative_humidity(
+    param_set::APS,
+    ts::ThermodynamicState{FT},
+) where {FT <: Real} = relative_humidity(
+    param_set,
+    air_temperature(param_set, ts),
+    air_pressure(param_set, ts),
+    typeof(ts),
+    PhasePartition(param_set, ts),
+)
 
-relative_humidity(ts::AbstractPhaseDry{FT}) where {FT <: Real} = FT(0)
+relative_humidity(param_set::APS, ts::AbstractPhaseDry{FT}) where {FT <: Real} =
+    FT(0)
 
 """
     total_specific_enthalpy(e_tot, R_m, T)
@@ -2430,18 +2463,20 @@ function total_specific_enthalpy(e_tot::FT, R_m::FT, T::FT) where {FT <: Real}
 end
 
 """
-    total_specific_enthalpy(ts)
+    total_specific_enthalpy(param_set, ts, e_tot::Real)
 
 Total specific enthalpy, given
- - `e_tot` total specific energy
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `ts` a thermodynamic state
+ - `e_tot` total specific energy
 """
 function total_specific_enthalpy(
+    param_set::APS,
     ts::ThermodynamicState{FT},
     e_tot::FT,
 ) where {FT <: Real}
-    R_m = gas_constant_air(ts)
-    T = air_temperature(ts)
+    R_m = gas_constant_air(param_set, ts)
+    T = air_temperature(param_set, ts)
     return total_specific_enthalpy(e_tot, R_m, T)
 end
 
@@ -2458,34 +2493,39 @@ function specific_enthalpy(e_int::FT, R_m::FT, T::FT) where {FT <: Real}
 end
 
 """
-    specific_enthalpy(ts)
+    specific_enthalpy(param_set, ts)
 
 Specific enthalpy, given a thermodynamic state `ts`.
 """
-function specific_enthalpy(ts::ThermodynamicState{FT}) where {FT <: Real}
-    e_int = internal_energy(ts)
-    R_m = gas_constant_air(ts)
-    T = air_temperature(ts)
+function specific_enthalpy(
+    param_set::APS,
+    ts::ThermodynamicState{FT},
+) where {FT <: Real}
+    e_int = internal_energy(param_set, ts)
+    R_m = gas_constant_air(param_set, ts)
+    T = air_temperature(param_set, ts)
     return specific_enthalpy(e_int, R_m, T)
 end
 
 """
-    moist_static_energy(ts, e_pot)
+    moist_static_energy(param_set, ts, e_pot)
 
 Moist static energy, given
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `ts` a thermodynamic state
  - `e_pot` potential energy (e.g., gravitational) per unit mass
 """
 function moist_static_energy(
+    param_set::APS,
     ts::ThermodynamicState{FT},
     e_pot::FT,
 ) where {FT <: Real}
-    return specific_enthalpy(ts) + e_pot
+    return specific_enthalpy(param_set, ts) + e_pot
 end
 
 """
     specific_entropy(param_set, p, T, q)
-    specific_entropy(ts)
+    specific_entropy(param_set, ts)
 
 Specific entropy, given
  - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
@@ -2508,11 +2548,11 @@ function specific_entropy(
     return (1 - q.tot) * s_d + q.tot * s_v - (q.liq * L_v + q.ice * L_s) / T
 end
 
-specific_entropy(ts::ThermodynamicState) = specific_entropy(
-    ts.param_set,
-    air_pressure(ts),
-    air_temperature(ts),
-    PhasePartition(ts),
+specific_entropy(param_set::APS, ts::ThermodynamicState) = specific_entropy(
+    param_set,
+    air_pressure(param_set, ts),
+    air_temperature(param_set, ts),
+    PhasePartition(param_set, ts),
 )
 
 """
@@ -2604,12 +2644,12 @@ function partial_pressure_vapor(
 end
 
 """
-    saturated(ts::ThermodynamicState)
+    saturated(param_set::APS, ts::ThermodynamicState)
 
 Boolean indicating if thermodynamic
 state is saturated.
 """
-function saturated(ts::ThermodynamicState)
-    RH = relative_humidity(ts)
+function saturated(param_set::APS, ts::ThermodynamicState)
+    RH = relative_humidity(param_set, ts)
     return RH ≈ 1 || RH > 1
 end

--- a/test/data_tests.jl
+++ b/test/data_tests.jl
@@ -48,7 +48,7 @@ end
         for (p, θ_liq_ice, q_tot) in zip(p_arr, θ_liq_ice_arr, q_tot_arr)
             @test_broken begin
                 ts = PhaseEquil_pθq(param_set, p, θ_liq_ice, q_tot, config...)
-                air_pressure(ts) == p
+                air_pressure(param_set, ts) == p
             end
         end
     end
@@ -75,7 +75,7 @@ end
         for (p, θ_liq_ice, q_tot) in zip(p_arr, θ_liq_ice_arr, q_tot_arr)
             @test begin
                 ts = PhaseEquil_pθq(param_set, p, θ_liq_ice, q_tot, config...)
-                air_pressure(ts) == p
+                air_pressure(param_set, ts) == p
             end
         end
     end

--- a/test/relations.jl
+++ b/test/relations.jl
@@ -15,13 +15,14 @@ using LinearAlgebra
 
 import CLIMAParameters
 const CP = CLIMAParameters
+const CPP = CP.Planet
 
 struct EarthParameterSet <: CP.AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
 # Tolerances for tested quantities:
 atol_temperature = 5e-1
-atol_energy = cv_d(param_set) * atol_temperature
+atol_energy = CPP.cv_d(param_set) * atol_temperature
 rtol_temperature = 1e-1
 rtol_density = rtol_temperature
 rtol_pressure = 1e-1
@@ -31,46 +32,46 @@ array_types = [Array{Float32}, Array{Float64}]
 
 include("data_tests.jl")
 
-compare_moisture(a::ThermodynamicState, b::ThermodynamicState) =
-    compare_moisture(a, PhasePartition(b))
+compare_moisture(param_set, a::ThermodynamicState, b::ThermodynamicState) =
+    compare_moisture(param_set, a, PhasePartition(param_set, b))
 
-compare_moisture(ts::PhaseEquil, q_pt::PhasePartition) =
-    getproperty(PhasePartition(ts), :tot) ≈ getproperty(q_pt, :tot)
+compare_moisture(param_set, ts::PhaseEquil, q_pt::PhasePartition) =
+    getproperty(PhasePartition(param_set, ts), :tot) ≈ getproperty(q_pt, :tot)
 
-compare_moisture(ts::PhaseNonEquil, q_pt::PhasePartition) = all((
-    getproperty(PhasePartition(ts), :tot) ≈ getproperty(q_pt, :tot),
-    getproperty(PhasePartition(ts), :liq) ≈ getproperty(q_pt, :liq),
-    getproperty(PhasePartition(ts), :ice) ≈ getproperty(q_pt, :ice),
+compare_moisture(param_set, ts::PhaseNonEquil, q_pt::PhasePartition) = all((
+    getproperty(PhasePartition(param_set, ts), :tot) ≈ getproperty(q_pt, :tot),
+    getproperty(PhasePartition(param_set, ts), :liq) ≈ getproperty(q_pt, :liq),
+    getproperty(PhasePartition(param_set, ts), :ice) ≈ getproperty(q_pt, :ice),
 ))
 
 @testset "Thermodynamics - isentropic processes" begin
     for ArrayType in array_types
         FT = eltype(ArrayType)
 
-        _R_d = FT(R_d(param_set))
-        _molmass_ratio = FT(molmass_ratio(param_set))
-        _cp_d = FT(cp_d(param_set))
-        _cp_v = FT(cp_v(param_set))
-        _cp_l = FT(cp_l(param_set))
-        _cv_d = FT(cv_d(param_set))
-        _cv_v = FT(cv_v(param_set))
-        _cv_l = FT(cv_l(param_set))
-        _cv_i = FT(cv_i(param_set))
-        _T_0 = FT(T_0(param_set))
-        _e_int_v0 = FT(e_int_v0(param_set))
-        _e_int_i0 = FT(e_int_i0(param_set))
-        _LH_v0 = FT(LH_v0(param_set))
-        _LH_s0 = FT(LH_s0(param_set))
-        _cp_i = FT(cp_i(param_set))
-        _LH_f0 = FT(LH_f0(param_set))
-        _press_triple = FT(press_triple(param_set))
-        _R_v = FT(R_v(param_set))
-        _T_triple = FT(T_triple(param_set))
-        _T_freeze = FT(T_freeze(param_set))
-        _T_min = FT(T_min(param_set))
-        _MSLP = FT(MSLP(param_set))
-        _T_max = FT(T_max(param_set))
-        _kappa_d = FT(kappa_d(param_set))
+        _R_d = FT(CPP.R_d(param_set))
+        _molmass_ratio = FT(CPP.molmass_ratio(param_set))
+        _cp_d = FT(CPP.cp_d(param_set))
+        _cp_v = FT(CPP.cp_v(param_set))
+        _cp_l = FT(CPP.cp_l(param_set))
+        _cv_d = FT(CPP.cv_d(param_set))
+        _cv_v = FT(CPP.cv_v(param_set))
+        _cv_l = FT(CPP.cv_l(param_set))
+        _cv_i = FT(CPP.cv_i(param_set))
+        _T_0 = FT(CPP.T_0(param_set))
+        _e_int_v0 = FT(CPP.e_int_v0(param_set))
+        _e_int_i0 = FT(CPP.e_int_i0(param_set))
+        _LH_v0 = FT(CPP.LH_v0(param_set))
+        _LH_s0 = FT(CPP.LH_s0(param_set))
+        _cp_i = FT(CPP.cp_i(param_set))
+        _LH_f0 = FT(CPP.LH_f0(param_set))
+        _press_triple = FT(CPP.press_triple(param_set))
+        _R_v = FT(CPP.R_v(param_set))
+        _T_triple = FT(CPP.T_triple(param_set))
+        _T_freeze = FT(CPP.T_freeze(param_set))
+        _T_min = FT(CPP.T_min(param_set))
+        _MSLP = FT(CPP.MSLP(param_set))
+        _T_max = FT(CPP.T_max(param_set))
+        _kappa_d = FT(CPP.kappa_d(param_set))
 
         profiles = TestedProfiles.PhaseEquilProfiles(param_set, ArrayType)
         @unpack T, p, e_int, ρ, θ_liq_ice, phase_type = profiles
@@ -102,31 +103,31 @@ end
 
 @testset "Thermodynamics - correctness" begin
     FT = Float64
-    _R_d = FT(R_d(param_set))
-    _molmass_ratio = FT(molmass_ratio(param_set))
-    _cp_d = FT(cp_d(param_set))
-    _cp_v = FT(cp_v(param_set))
-    _cp_l = FT(cp_l(param_set))
-    _cv_d = FT(cv_d(param_set))
-    _cv_v = FT(cv_v(param_set))
-    _cv_l = FT(cv_l(param_set))
-    _cv_i = FT(cv_i(param_set))
-    _T_0 = FT(T_0(param_set))
-    _e_int_v0 = FT(e_int_v0(param_set))
-    _e_int_i0 = FT(e_int_i0(param_set))
-    _LH_v0 = FT(LH_v0(param_set))
-    _LH_s0 = FT(LH_s0(param_set))
-    _cp_i = FT(cp_i(param_set))
-    _LH_f0 = FT(LH_f0(param_set))
-    _press_triple = FT(press_triple(param_set))
-    _R_v = FT(R_v(param_set))
-    _T_triple = FT(T_triple(param_set))
-    _T_freeze = FT(T_freeze(param_set))
-    _T_min = FT(T_min(param_set))
-    _MSLP = FT(MSLP(param_set))
-    _T_max = FT(T_max(param_set))
-    _kappa_d = FT(kappa_d(param_set))
-    _T_icenuc = FT(T_icenuc(param_set))
+    _R_d = FT(CPP.R_d(param_set))
+    _molmass_ratio = FT(CPP.molmass_ratio(param_set))
+    _cp_d = FT(CPP.cp_d(param_set))
+    _cp_v = FT(CPP.cp_v(param_set))
+    _cp_l = FT(CPP.cp_l(param_set))
+    _cv_d = FT(CPP.cv_d(param_set))
+    _cv_v = FT(CPP.cv_v(param_set))
+    _cv_l = FT(CPP.cv_l(param_set))
+    _cv_i = FT(CPP.cv_i(param_set))
+    _T_0 = FT(CPP.T_0(param_set))
+    _e_int_v0 = FT(CPP.e_int_v0(param_set))
+    _e_int_i0 = FT(CPP.e_int_i0(param_set))
+    _LH_v0 = FT(CPP.LH_v0(param_set))
+    _LH_s0 = FT(CPP.LH_s0(param_set))
+    _cp_i = FT(CPP.cp_i(param_set))
+    _LH_f0 = FT(CPP.LH_f0(param_set))
+    _press_triple = FT(CPP.press_triple(param_set))
+    _R_v = FT(CPP.R_v(param_set))
+    _T_triple = FT(CPP.T_triple(param_set))
+    _T_freeze = FT(CPP.T_freeze(param_set))
+    _T_min = FT(CPP.T_min(param_set))
+    _MSLP = FT(CPP.MSLP(param_set))
+    _T_max = FT(CPP.T_max(param_set))
+    _kappa_d = FT(CPP.kappa_d(param_set))
+    _T_icenuc = FT(CPP.T_icenuc(param_set))
 
     # ideal gas law
     @test air_pressure(param_set, FT(1), FT(1), PhasePartition(FT(1))) === _R_v
@@ -223,13 +224,18 @@ end
     ts = PhaseNonEquil(param_set, e_int, ρ, q_pt)
     @test q_vap_saturation_generic(
         param_set,
-        air_temperature(ts),
+        air_temperature(param_set, ts),
         ρ,
         Liquid(),
-    ) ≈ q_vap_saturation_liquid(ts)
-    @test q_vap_saturation_generic(param_set, air_temperature(ts), ρ, Ice()) ≈
-          q_vap_saturation_ice(ts)
-    @test q_vap_saturation_ice(ts) <= q_vap_saturation_liquid(ts)
+    ) ≈ q_vap_saturation_liquid(param_set, ts)
+    @test q_vap_saturation_generic(
+        param_set,
+        air_temperature(param_set, ts),
+        ρ,
+        Ice(),
+    ) ≈ q_vap_saturation_ice(param_set, ts)
+    @test q_vap_saturation_ice(param_set, ts) <=
+          q_vap_saturation_liquid(param_set, ts)
 
     phase_type = PhaseDry
     @test saturation_excess(
@@ -489,11 +495,11 @@ end
         RH_sat_mask = or.(RH .> 1, RH .≈ 1)
         RH_unsat_mask = .!or.(RH .> 1, RH .≈ 1)
         ts = PhaseEquil_ρeq.(param_set, ρ, e_int, q_tot)
-        @test all(saturated.(ts[RH_sat_mask]))
-        @test !any(saturated.(ts[RH_unsat_mask]))
+        @test all(saturated.(param_set, ts[RH_sat_mask]))
+        @test !any(saturated.(param_set, ts[RH_unsat_mask]))
 
         # PhaseEquil (freezing)
-        _T_freeze = FT(T_freeze(param_set))
+        _T_freeze = FT(CPP.T_freeze(param_set))
         e_int_upper =
             internal_energy_sat.(
                 param_set,
@@ -512,7 +518,7 @@ end
             )
         _e_int = (e_int_upper .+ e_int_lower) / 2
         ts = PhaseEquil_ρeq.(param_set, ρ, _e_int, q_tot)
-        @test all(air_temperature.(ts) .== Ref(_T_freeze))
+        @test all(air_temperature.(param_set, ts) .== Ref(_T_freeze))
 
         # Args needs to be in sync with PhaseEquil:
         ts =
@@ -525,26 +531,35 @@ end
                 FT(1e-1),
                 RS.SecantMethod,
             )
-        @test all(air_temperature.(ts) .== Ref(_T_freeze))
+        @test all(air_temperature.(param_set, ts) .== Ref(_T_freeze))
 
         # PhaseEquil
         ts_exact = PhaseEquil_ρeq.(param_set, ρ, e_int, q_tot, 100, FT(1e-3))
         ts = PhaseEquil_ρeq.(param_set, ρ, e_int, q_tot)
-        @test all(isapprox.(T, air_temperature.(ts), rtol = rtol_temperature))
+        @test all(isapprox.(
+            T,
+            air_temperature.(param_set, ts),
+            rtol = rtol_temperature,
+        ))
 
         # Should be machine accurate (because ts contains `e_int`,`ρ`,`q_tot`):
-        @test all(compare_moisture.(ts, ts_exact))
-        @test all(internal_energy.(ts) .≈ internal_energy.(ts_exact))
-        @test all(air_density.(ts) .≈ air_density.(ts_exact))
+        @test all(compare_moisture.(param_set, ts, ts_exact))
+        @test all(
+            internal_energy.(param_set, ts) .≈
+            internal_energy.(param_set, ts_exact),
+        )
+        @test all(
+            air_density.(param_set, ts) .≈ air_density.(param_set, ts_exact),
+        )
         # Approximate (temperature must be computed via saturation adjustment):
         @test all(isapprox.(
-            air_pressure.(ts),
-            air_pressure.(ts_exact),
+            air_pressure.(param_set, ts),
+            air_pressure.(param_set, ts_exact),
             rtol = rtol_pressure,
         ))
         @test all(isapprox.(
-            air_temperature.(ts),
-            air_temperature.(ts_exact),
+            air_temperature.(param_set, ts),
+            air_temperature.(param_set, ts_exact),
             rtol = rtol_temperature,
         ))
 
@@ -556,21 +571,23 @@ end
         )
         @test all(has_condensate.(q_dry) .== false)
 
-        e_tot = total_energy.(e_kin, e_pot, ts)
+        e_tot = total_energy.(param_set, ts, e_kin, e_pot)
         @test all(
-            specific_enthalpy.(ts) .≈
-            e_int .+ gas_constant_air.(ts) .* air_temperature.(ts),
+            specific_enthalpy.(param_set, ts) .≈
+            e_int .+
+            gas_constant_air.(param_set, ts) .* air_temperature.(param_set, ts),
         )
         @test all(
-            total_specific_enthalpy.(ts, e_tot) .≈
-            specific_enthalpy.(ts) .+ e_kin .+ e_pot,
+            total_specific_enthalpy.(param_set, ts, e_tot) .≈
+            specific_enthalpy.(param_set, ts) .+ e_kin .+ e_pot,
         )
         @test all(
-            moist_static_energy.(ts, e_pot) .≈ specific_enthalpy.(ts) .+ e_pot,
+            moist_static_energy.(param_set, ts, e_pot) .≈
+            specific_enthalpy.(param_set, ts) .+ e_pot,
         )
         @test all(
-            moist_static_energy.(ts, e_pot) .≈
-            total_specific_enthalpy.(ts, e_tot) .- e_kin,
+            moist_static_energy.(param_set, ts, e_pot) .≈
+            total_specific_enthalpy.(param_set, ts, e_tot) .- e_kin,
         )
 
         # PhaseEquil
@@ -595,18 +612,23 @@ end
                 RS.SecantMethod,
             ) # Needs to be in sync with default
         # Should be machine accurate (because ts contains `e_int`,`ρ`,`q_tot`):
-        @test all(compare_moisture.(ts, ts_exact))
-        @test all(internal_energy.(ts) .≈ internal_energy.(ts_exact))
-        @test all(air_density.(ts) .≈ air_density.(ts_exact))
+        @test all(compare_moisture.(param_set, ts, ts_exact))
+        @test all(
+            internal_energy.(param_set, ts) .≈
+            internal_energy.(param_set, ts_exact),
+        )
+        @test all(
+            air_density.(param_set, ts) .≈ air_density.(param_set, ts_exact),
+        )
         # Approximate (temperature must be computed via saturation adjustment):
         @test all(isapprox.(
-            air_pressure.(ts),
-            air_pressure.(ts_exact),
+            air_pressure.(param_set, ts),
+            air_pressure.(param_set, ts_exact),
             rtol = rtol_pressure,
         ))
         @test all(isapprox.(
-            air_temperature.(ts),
-            air_temperature.(ts_exact),
+            air_temperature.(param_set, ts),
+            air_temperature.(param_set, ts_exact),
             rtol = rtol_temperature,
         ))
 
@@ -614,22 +636,24 @@ end
         ts_exact = PhaseEquil_ρθq.(param_set, ρ, θ_liq_ice, q_tot, 45, FT(1e-3))
         ts = PhaseEquil_ρθq.(param_set, ρ, θ_liq_ice, q_tot)
         # Should be machine accurate:
-        @test all(air_density.(ts) .≈ air_density.(ts_exact))
-        @test all(compare_moisture.(ts, ts_exact))
+        @test all(
+            air_density.(param_set, ts) .≈ air_density.(param_set, ts_exact),
+        )
+        @test all(compare_moisture.(param_set, ts, ts_exact))
         # Approximate (temperature must be computed via saturation adjustment):
         @test all(isapprox.(
-            internal_energy.(ts),
-            internal_energy.(ts_exact),
+            internal_energy.(param_set, ts),
+            internal_energy.(param_set, ts_exact),
             atol = atol_energy,
         ))
         @test all(isapprox.(
-            liquid_ice_pottemp.(ts),
-            liquid_ice_pottemp.(ts_exact),
+            liquid_ice_pottemp.(param_set, ts),
+            liquid_ice_pottemp.(param_set, ts_exact),
             rtol = rtol_temperature,
         ))
         @test all(isapprox.(
-            air_temperature.(ts),
-            air_temperature.(ts_exact),
+            air_temperature.(param_set, ts),
+            air_temperature.(param_set, ts_exact),
             rtol = rtol_temperature,
         ))
 
@@ -648,31 +672,31 @@ end
                 RS.RegulaFalsiMethod,
             )
         # Should be machine accurate:
-        @test all(compare_moisture.(ts, ts_exact))
+        @test all(compare_moisture.(param_set, ts, ts_exact))
         # Approximate (temperature must be computed via saturation adjustment):
         @test all(isapprox.(
-            air_density.(ts),
-            air_density.(ts_exact),
+            air_density.(param_set, ts),
+            air_density.(param_set, ts_exact),
             rtol = rtol_density,
         ))
         @test all(isapprox.(
-            internal_energy.(ts),
-            internal_energy.(ts_exact),
+            internal_energy.(param_set, ts),
+            internal_energy.(param_set, ts_exact),
             atol = atol_energy,
         ))
         @test all(isapprox.(
-            liquid_ice_pottemp.(ts),
-            liquid_ice_pottemp.(ts_exact),
+            liquid_ice_pottemp.(param_set, ts),
+            liquid_ice_pottemp.(param_set, ts_exact),
             rtol = rtol_temperature,
         ))
         @test all(isapprox.(
-            air_temperature.(ts),
-            air_temperature.(ts_exact),
+            air_temperature.(param_set, ts),
+            air_temperature.(param_set, ts_exact),
             rtol = rtol_temperature,
         ))
 
         # PhaseEquil_pθq (freezing)
-        _T_freeze = FT(T_freeze(param_set))
+        _T_freeze = FT(CPP.T_freeze(param_set))
 
         function θ_liq_ice_closure(T, p, q_tot)
             q_pt_closure = TD.PhasePartition_equil_given_p(
@@ -701,15 +725,18 @@ end
         ts_upper = PhaseEquil_pθq.(param_set, p, θ_liq_ice_upper, q_tot)
         ts_mid = PhaseEquil_pθq.(param_set, p, θ_liq_ice_mid, q_tot)
 
-        @test count(air_temperature.(ts_lower) .== Ref(_T_freeze)) ≥ 217
-        @test count(air_temperature.(ts_upper) .== Ref(_T_freeze)) ≥ 217
-        @test count(air_temperature.(ts_mid) .== Ref(_T_freeze)) ≥ 1392
+        @test count(air_temperature.(param_set, ts_lower) .== Ref(_T_freeze)) ≥
+              217
+        @test count(air_temperature.(param_set, ts_upper) .== Ref(_T_freeze)) ≥
+              217
+        @test count(air_temperature.(param_set, ts_mid) .== Ref(_T_freeze)) ≥
+              1392
         # we should do this instead, but we're failing because some inputs are bad
         # E.g. p ~ 110_000 Pa, q_tot ~ 0.16, which results in negative θ_liq_ice
         # This means that we should probably update our tested profiles.
-        # @test all(air_temperature.(ts_lower) .== Ref(_T_freeze))
-        # @test all(air_temperature.(ts_upper) .== Ref(_T_freeze))
-        # @test all(air_temperature.(ts_mid) .== Ref(_T_freeze))
+        # @test all(air_temperature.(param_set, ts_lower) .== Ref(_T_freeze))
+        # @test all(air_temperature.(param_set, ts_upper) .== Ref(_T_freeze))
+        # @test all(air_temperature.(param_set, ts_mid) .== Ref(_T_freeze))
 
         # @show ρ, θ_liq_ice, q_pt
         # PhaseNonEquil_ρθq
@@ -717,22 +744,24 @@ end
             PhaseNonEquil_ρθq.(param_set, ρ, θ_liq_ice, q_pt, 40, FT(1e-3))
         ts = PhaseNonEquil_ρθq.(param_set, ρ, θ_liq_ice, q_pt)
         # Should be machine accurate:
-        @test all(compare_moisture.(ts, ts_exact))
-        @test all(air_density.(ts) .≈ air_density.(ts_exact))
+        @test all(compare_moisture.(param_set, ts, ts_exact))
+        @test all(
+            air_density.(param_set, ts) .≈ air_density.(param_set, ts_exact),
+        )
         # Approximate (temperature must be computed via non-linear solve):
         @test all(isapprox.(
-            internal_energy.(ts),
-            internal_energy.(ts_exact),
+            internal_energy.(param_set, ts),
+            internal_energy.(param_set, ts_exact),
             atol = atol_energy,
         ))
         @test all(isapprox.(
-            liquid_ice_pottemp.(ts),
-            liquid_ice_pottemp.(ts_exact),
+            liquid_ice_pottemp.(param_set, ts),
+            liquid_ice_pottemp.(param_set, ts_exact),
             rtol = rtol_temperature,
         ))
         @test all(isapprox.(
-            air_temperature.(ts),
-            air_temperature.(ts_exact),
+            air_temperature.(param_set, ts),
+            air_temperature.(param_set, ts_exact),
             rtol = rtol_temperature,
         ))
 
@@ -852,7 +881,7 @@ end
 
     for ArrayType in array_types
         FT = eltype(ArrayType)
-        _MSLP = FT(MSLP(param_set))
+        _MSLP = FT(CPP.MSLP(param_set))
 
         profiles = TestedProfiles.PhaseDryProfiles(param_set, ArrayType)
         @unpack T, p, e_int, ρ, θ_liq_ice, phase_type = profiles
@@ -860,38 +889,53 @@ end
 
         # PhaseDry
         ts = PhaseDry.(param_set, e_int, ρ)
-        @test all(internal_energy.(ts) .≈ e_int)
-        @test all(air_density.(ts) .≈ ρ)
+        @test all(internal_energy.(param_set, ts) .≈ e_int)
+        @test all(air_density.(param_set, ts) .≈ ρ)
 
         ts_pT = PhaseDry_pT.(param_set, p, T)
-        @test all(internal_energy.(ts_pT) .≈ internal_energy.(param_set, T))
-        @test all(air_density.(ts_pT) .≈ ρ)
+        @test all(
+            internal_energy.(param_set, ts_pT) .≈
+            internal_energy.(param_set, T),
+        )
+        @test all(air_density.(param_set, ts_pT) .≈ ρ)
 
         θ_dry = dry_pottemp.(param_set, T, ρ)
         ts_pθ = PhaseDry_pθ.(param_set, p, θ_dry)
-        @test all(internal_energy.(ts_pθ) .≈ internal_energy.(param_set, T))
-        @test all(air_density.(ts_pθ) .≈ ρ)
+        @test all(
+            internal_energy.(param_set, ts_pθ) .≈
+            internal_energy.(param_set, T),
+        )
+        @test all(air_density.(param_set, ts_pθ) .≈ ρ)
 
         p_dry = air_pressure.(param_set, T, ρ)
         ts_pe = PhaseDry_pe.(param_set, p, e_int)
-        @test all(internal_energy.(ts_pe) .≈ internal_energy.(param_set, T))
-        @test all(air_pressure.(ts_pe) .≈ p_dry)
+        @test all(
+            internal_energy.(param_set, ts_pe) .≈
+            internal_energy.(param_set, T),
+        )
+        @test all(air_pressure.(param_set, ts_pe) .≈ p_dry)
 
         ts_ρθ = PhaseDry_ρθ.(param_set, ρ, θ_dry)
-        @test all(internal_energy.(ts_ρθ) .≈ internal_energy.(param_set, T))
-        @test all(air_density.(ts_ρθ) .≈ ρ)
+        @test all(
+            internal_energy.(param_set, ts_ρθ) .≈
+            internal_energy.(param_set, T),
+        )
+        @test all(air_density.(param_set, ts_ρθ) .≈ ρ)
 
         ts_ρT = PhaseDry_ρT.(param_set, ρ, T)
-        @test all(air_density.(ts_ρT) .≈ air_density.(ts))
-        @test all(internal_energy.(ts_ρT) .≈ internal_energy.(ts))
+        @test all(air_density.(param_set, ts_ρT) .≈ air_density.(param_set, ts))
+        @test all(
+            internal_energy.(param_set, ts_ρT) .≈
+            internal_energy.(param_set, ts),
+        )
 
 
         ts = PhaseDry_ρp.(param_set, ρ, p)
-        @test all(air_density.(ts) .≈ ρ)
-        @test all(air_pressure.(ts) .≈ p)
+        @test all(air_density.(param_set, ts) .≈ ρ)
+        @test all(air_pressure.(param_set, ts) .≈ p)
         e_tot_proposed =
             TD.total_energy_given_ρp.(param_set, ρ, p, e_kin, e_pot)
-        @test all(total_energy.(e_kin, e_pot, ts) .≈ e_tot_proposed)
+        @test all(total_energy.(param_set, ts, e_kin, e_pot) .≈ e_tot_proposed)
 
 
         profiles = TestedProfiles.PhaseEquilProfiles(param_set, ArrayType)
@@ -909,46 +953,50 @@ end
                 FT(1e-1),
                 RS.SecantMethod,
             )
-        @test all(internal_energy.(ts) .≈ e_int)
-        @test all(getproperty.(PhasePartition.(ts), :tot) .≈ q_tot)
-        @test all(air_density.(ts) .≈ ρ)
+        @test all(internal_energy.(param_set, ts) .≈ e_int)
+        @test all(getproperty.(PhasePartition.(param_set, ts), :tot) .≈ q_tot)
+        @test all(air_density.(param_set, ts) .≈ ρ)
 
         ts = PhaseEquil_ρeq.(param_set, ρ, e_int, q_tot)
-        @test all(internal_energy.(ts) .≈ e_int)
-        @test all(getproperty.(PhasePartition.(ts), :tot) .≈ q_tot)
-        @test all(air_density.(ts) .≈ ρ)
+        @test all(internal_energy.(param_set, ts) .≈ e_int)
+        @test all(getproperty.(PhasePartition.(param_set, ts), :tot) .≈ q_tot)
+        @test all(air_density.(param_set, ts) .≈ ρ)
 
         ts_peq = PhaseEquil_peq.(param_set, p, e_int, q_tot)
-        @test all(internal_energy.(ts_peq) .≈ e_int)
-        @test all(getproperty.(PhasePartition.(ts_peq), :tot) .≈ q_tot)
-        @test all(air_pressure.(ts_peq) .≈ p)
+        @test all(internal_energy.(param_set, ts_peq) .≈ e_int)
+        @test all(
+            getproperty.(PhasePartition.(param_set, ts_peq), :tot) .≈ q_tot,
+        )
+        @test all(air_pressure.(param_set, ts_peq) .≈ p)
 
         ts_pθq = PhaseEquil_pθq.(param_set, p, θ_liq_ice, q_tot)
-        @test all(air_pressure.(ts_pθq) .≈ p)
+        @test all(air_pressure.(param_set, ts_pθq) .≈ p)
         # TODO: Run some tests to make sure that this decreses with
         # decreasing temperature_tol (and increasing maxiter)
-        # @show maximum(abs.(liquid_ice_pottemp.(ts_pθq) .- θ_liq_ice))
+        # @show maximum(abs.(liquid_ice_pottemp.(param_set, ts_pθq) .- θ_liq_ice))
         @test all(isapprox.(
-            liquid_ice_pottemp.(ts_pθq),
+            liquid_ice_pottemp.(param_set, ts_pθq),
             θ_liq_ice,
             rtol = rtol_temperature,
         ))
-        @test all(getproperty.(PhasePartition.(ts_pθq), :tot) .≈ q_tot)
+        @test all(
+            getproperty.(PhasePartition.(param_set, ts_pθq), :tot) .≈ q_tot,
+        )
 
         # We can't pass on this yet, due to https://github.com/CliMA/ClimateMachine.jl/issues/263
         # ts_pθq = PhaseEquil_pθq.(param_set, p, θ_liq_ice, q_tot, 40, FT(1e-3), RS.NewtonsMethodAD)
-        # @test all(air_pressure.(ts_pθq) .≈ p)
+        # @test all(air_pressure.(param_set, ts_pθq) .≈ p)
         # @test all(isapprox.(
-        #     liquid_ice_pottemp.(ts_pθq),
+        #     liquid_ice_pottemp.(param_set, ts_pθq),
         #     θ_liq_ice,
         #     rtol = rtol_temperature,
         # ))
-        # @test all(getproperty.(PhasePartition.(ts_pθq), :tot) .≈ q_tot)
+        # @test all(getproperty.(PhasePartition.(param_set, ts_pθq), :tot) .≈ q_tot)
 
         ts = PhaseEquil_ρpq.(param_set, ρ, p, q_tot, true)
-        @test all(air_density.(ts) .≈ ρ)
-        @test all(air_pressure.(ts) .≈ p)
-        @test all(getproperty.(PhasePartition.(ts), :tot) .≈ q_tot)
+        @test all(air_density.(param_set, ts) .≈ ρ)
+        @test all(air_pressure.(param_set, ts) .≈ p)
+        @test all(getproperty.(PhasePartition.(param_set, ts), :tot) .≈ q_tot)
 
         # Test against total_energy_given_ρp when not iterating
         ts = PhaseEquil_ρpq.(param_set, ρ, p, q_tot, false)
@@ -961,18 +1009,18 @@ end
                 e_pot,
                 PhasePartition.(q_tot),
             )
-        @test all(total_energy.(e_kin, e_pot, ts) .≈ e_tot_proposed)
+        @test all(total_energy.(param_set, ts, e_kin, e_pot) .≈ e_tot_proposed)
 
         # PhaseNonEquil
         ts = PhaseNonEquil.(param_set, e_int, ρ, q_pt)
-        @test all(internal_energy.(ts) .≈ e_int)
-        @test all(compare_moisture.(ts, q_pt))
-        @test all(air_density.(ts) .≈ ρ)
+        @test all(internal_energy.(param_set, ts) .≈ e_int)
+        @test all(compare_moisture.(param_set, ts, q_pt))
+        @test all(air_density.(param_set, ts) .≈ ρ)
 
         ts = PhaseNonEquil_peq.(param_set, p, e_int, q_pt)
-        @test all(internal_energy.(ts) .≈ e_int)
-        @test all(compare_moisture.(ts, q_pt))
-        @test all(air_pressure.(ts) .≈ p)
+        @test all(internal_energy.(param_set, ts) .≈ e_int)
+        @test all(compare_moisture.(param_set, ts, q_pt))
+        @test all(air_pressure.(param_set, ts) .≈ p)
 
         # TD.air_temperature_given_pθq-liquid_ice_pottemp inverse
         θ_liq_ice_ =
@@ -1003,22 +1051,26 @@ end
         @test all(isapprox.(T_non_linear, T_expansion, rtol = rtol_temperature))
         e_int_ = internal_energy.(param_set, T_non_linear, q_pt)
         ts = PhaseNonEquil.(param_set, e_int_, ρ, q_pt)
-        @test all(T_non_linear .≈ air_temperature.(ts))
+        @test all(T_non_linear .≈ air_temperature.(param_set, ts))
         @test all(isapprox(
             θ_liq_ice,
-            liquid_ice_pottemp.(ts),
+            liquid_ice_pottemp.(param_set, ts),
             rtol = rtol_temperature,
         ))
 
         # PhaseEquil_ρθq
         ts = PhaseEquil_ρθq.(param_set, ρ, θ_liq_ice, q_tot, 45, FT(1e-3))
         @test all(isapprox.(
-            liquid_ice_pottemp.(ts),
+            liquid_ice_pottemp.(param_set, ts),
             θ_liq_ice,
             rtol = rtol_temperature,
         ))
-        @test all(isapprox.(air_density.(ts), ρ, rtol = rtol_density))
-        @test all(getproperty.(PhasePartition.(ts), :tot) .≈ q_tot)
+        @test all(isapprox.(
+            air_density.(param_set, ts),
+            ρ,
+            rtol = rtol_density,
+        ))
+        @test all(getproperty.(PhasePartition.(param_set, ts), :tot) .≈ q_tot)
 
         # The PhaseEquil_pθq constructor
         # passes the consistency test within sufficient physical precision,
@@ -1028,44 +1080,47 @@ end
         # PhaseEquil_pθq
         ts = PhaseEquil_pθq.(param_set, p, θ_liq_ice, q_tot, 35, FT(1e-3))
         @test all(isapprox.(
-            liquid_ice_pottemp.(ts),
+            liquid_ice_pottemp.(param_set, ts),
             θ_liq_ice,
             rtol = rtol_temperature,
         ))
-        @test all(compare_moisture.(ts, q_pt))
-        @test all(air_pressure.(ts) .≈ p)
+        @test all(compare_moisture.(param_set, ts, q_pt))
+        @test all(air_pressure.(param_set, ts) .≈ p)
 
         # PhaseNonEquil_pθq
         ts = PhaseNonEquil_pθq.(param_set, p, θ_liq_ice, q_pt)
-        @test all(liquid_ice_pottemp.(ts) .≈ θ_liq_ice)
-        @test all(air_pressure.(ts) .≈ p)
-        @test all(compare_moisture.(ts, q_pt))
+        @test all(liquid_ice_pottemp.(param_set, ts) .≈ θ_liq_ice)
+        @test all(air_pressure.(param_set, ts) .≈ p)
+        @test all(compare_moisture.(param_set, ts, q_pt))
 
         ts = PhaseNonEquil_ρpq.(param_set, ρ, p, q_pt)
-        @test all(air_density.(ts) .≈ ρ)
-        @test all(air_pressure.(ts) .≈ p)
+        @test all(air_density.(param_set, ts) .≈ ρ)
+        @test all(air_pressure.(param_set, ts) .≈ p)
         @test all(
-            getproperty.(PhasePartition.(ts), :tot) .≈ getproperty.(q_pt, :tot),
+            getproperty.(PhasePartition.(param_set, ts), :tot) .≈
+            getproperty.(q_pt, :tot),
         )
         @test all(
-            getproperty.(PhasePartition.(ts), :liq) .≈ getproperty.(q_pt, :liq),
+            getproperty.(PhasePartition.(param_set, ts), :liq) .≈
+            getproperty.(q_pt, :liq),
         )
         @test all(
-            getproperty.(PhasePartition.(ts), :ice) .≈ getproperty.(q_pt, :ice),
+            getproperty.(PhasePartition.(param_set, ts), :ice) .≈
+            getproperty.(q_pt, :ice),
         )
         e_tot_proposed =
             TD.total_energy_given_ρp.(param_set, ρ, p, e_kin, e_pot, q_pt)
-        @test all(total_energy.(e_kin, e_pot, ts) .≈ e_tot_proposed)
+        @test all(total_energy.(param_set, ts, e_kin, e_pot) .≈ e_tot_proposed)
 
         # PhaseNonEquil_ρθq
         ts = PhaseNonEquil_ρθq.(param_set, ρ, θ_liq_ice, q_pt, 5, FT(1e-3))
         @test all(isapprox.(
             θ_liq_ice,
-            liquid_ice_pottemp.(ts),
+            liquid_ice_pottemp.(param_set, ts),
             rtol = rtol_temperature,
         ))
-        @test all(air_density.(ts) .≈ ρ)
-        @test all(compare_moisture.(ts, q_pt))
+        @test all(air_density.(param_set, ts) .≈ ρ)
+        @test all(compare_moisture.(param_set, ts, q_pt))
 
         profiles = TestedProfiles.PhaseEquilProfiles(param_set, ArrayType)
         @unpack T, p, e_int, ρ, θ_liq_ice, phase_type = profiles
@@ -1101,7 +1156,7 @@ end
 
 
         # Test virtual temperature and inverse functions:
-        _R_d = FT(R_d(param_set))
+        _R_d = FT(CPP.R_d(param_set))
         T_virt = virtual_temperature.(param_set, T, ρ, q_pt)
         @test all(T_virt ≈ gas_constant_air.(param_set, q_pt) ./ _R_d .* T)
 
@@ -1167,34 +1222,39 @@ end
           typeof.(e_int)
 
     ts_eq = PhaseEquil_ρeq.(param_set, ρ, e_int, q_tot, 15, FT(1e-1))
-    e_tot = total_energy.(e_kin, e_pot, ts_eq)
+    e_tot = total_energy.(param_set, ts_eq, e_kin, e_pot)
 
     ts_T =
         PhaseEquil_ρTq.(
             param_set,
-            air_density.(ts_eq),
-            air_temperature.(ts_eq),
+            air_density.(param_set, ts_eq),
+            air_temperature.(param_set, ts_eq),
             q_tot,
         )
     ts_Tp =
         PhaseEquil_pTq.(
             param_set,
-            air_pressure.(ts_eq),
-            air_temperature.(ts_eq),
+            air_pressure.(param_set, ts_eq),
+            air_temperature.(param_set, ts_eq),
             q_tot,
         )
 
     ts_ρp =
         PhaseEquil_ρpq.(
             param_set,
-            air_density.(ts_eq),
-            air_pressure.(ts_eq),
+            air_density.(param_set, ts_eq),
+            air_pressure.(param_set, ts_eq),
             q_tot,
         )
 
-    @test all(air_temperature.(ts_T) .≈ air_temperature.(ts_Tp))
-    @test all(air_pressure.(ts_T) .≈ air_pressure.(ts_Tp))
-    @test all(total_specific_humidity.(ts_T) .≈ total_specific_humidity.(ts_Tp))
+    @test all(
+        air_temperature.(param_set, ts_T) .≈ air_temperature.(param_set, ts_Tp),
+    )
+    @test all(air_pressure.(param_set, ts_T) .≈ air_pressure.(param_set, ts_Tp))
+    @test all(
+        total_specific_humidity.(param_set, ts_T) .≈
+        total_specific_humidity.(param_set, ts_Tp),
+    )
 
     ts_neq = PhaseNonEquil.(param_set, e_int, ρ, q_pt)
     ts_ρT_neq = PhaseNonEquil_ρTq.(param_set, ρ, T, q_pt)
@@ -1225,47 +1285,52 @@ end
         ts_θ_liq_ice_neq,
         ts_θ_liq_ice_neq_p,
     )
-        @test typeof.(soundspeed_air.(ts)) == typeof.(e_int)
-        @test typeof.(gas_constant_air.(ts)) == typeof.(e_int)
-        @test typeof.(specific_enthalpy.(ts)) == typeof.(e_int)
-        @test typeof.(vapor_specific_humidity.(ts)) == typeof.(e_int)
-        @test typeof.(relative_humidity.(ts)) == typeof.(e_int)
-        @test typeof.(air_pressure.(ts)) == typeof.(e_int)
-        @test typeof.(air_density.(ts)) == typeof.(e_int)
-        @test typeof.(total_specific_humidity.(ts)) == typeof.(e_int)
-        @test typeof.(liquid_specific_humidity.(ts)) == typeof.(e_int)
-        @test typeof.(ice_specific_humidity.(ts)) == typeof.(e_int)
-        @test typeof.(cp_m.(ts)) == typeof.(e_int)
-        @test typeof.(cv_m.(ts)) == typeof.(e_int)
-        @test typeof.(air_temperature.(ts)) == typeof.(e_int)
-        @test typeof.(internal_energy_sat.(ts)) == typeof.(e_int)
-        @test typeof.(internal_energy.(ts)) == typeof.(e_int)
-        @test typeof.(internal_energy_dry.(ts)) == typeof.(e_int)
-        @test typeof.(internal_energy_vapor.(ts)) == typeof.(e_int)
-        @test typeof.(internal_energy_liquid.(ts)) == typeof.(e_int)
-        @test typeof.(internal_energy_ice.(ts)) == typeof.(e_int)
-        @test typeof.(latent_heat_vapor.(ts)) == typeof.(e_int)
-        @test typeof.(latent_heat_sublim.(ts)) == typeof.(e_int)
-        @test typeof.(latent_heat_fusion.(ts)) == typeof.(e_int)
-        @test typeof.(q_vap_saturation.(ts)) == typeof.(e_int)
-        @test typeof.(q_vap_saturation_liquid.(ts)) == typeof.(e_int)
-        @test typeof.(q_vap_saturation_ice.(ts)) == typeof.(e_int)
-        @test typeof.(saturation_excess.(ts)) == typeof.(e_int)
-        @test typeof.(liquid_fraction.(ts)) == typeof.(e_int)
-        @test typeof.(liquid_ice_pottemp.(ts)) == typeof.(e_int)
-        @test typeof.(dry_pottemp.(ts)) == typeof.(e_int)
-        @test typeof.(exner.(ts)) == typeof.(e_int)
-        @test typeof.(liquid_ice_pottemp_sat.(ts)) == typeof.(e_int)
-        @test typeof.(specific_volume.(ts)) == typeof.(e_int)
-        @test typeof.(supersaturation.(ts, Ice())) == typeof.(e_int)
-        @test typeof.(supersaturation.(ts, Liquid())) == typeof.(e_int)
-        @test typeof.(virtual_pottemp.(ts)) == typeof.(e_int)
-        @test typeof.(specific_entropy.(ts)) == typeof.(e_int)
-        @test eltype.(gas_constants.(ts)) == typeof.(e_int)
+        @test typeof.(soundspeed_air.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(gas_constant_air.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(specific_enthalpy.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(vapor_specific_humidity.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(relative_humidity.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(air_pressure.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(air_density.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(total_specific_humidity.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(liquid_specific_humidity.(param_set, ts)) ==
+              typeof.(e_int)
+        @test typeof.(ice_specific_humidity.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(cp_m.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(cv_m.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(air_temperature.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(internal_energy_sat.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(internal_energy.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(internal_energy_dry.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(internal_energy_vapor.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(internal_energy_liquid.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(internal_energy_ice.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(latent_heat_vapor.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(latent_heat_sublim.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(latent_heat_fusion.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(q_vap_saturation.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(q_vap_saturation_liquid.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(q_vap_saturation_ice.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(saturation_excess.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(liquid_fraction.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(liquid_ice_pottemp.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(dry_pottemp.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(exner.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(liquid_ice_pottemp_sat.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(specific_volume.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(supersaturation.(param_set, ts, Ice())) == typeof.(e_int)
+        @test typeof.(supersaturation.(param_set, ts, Liquid())) ==
+              typeof.(e_int)
+        @test typeof.(virtual_pottemp.(param_set, ts)) == typeof.(e_int)
+        @test typeof.(specific_entropy.(param_set, ts)) == typeof.(e_int)
+        @test eltype.(gas_constants.(param_set, ts)) == typeof.(e_int)
 
-        @test typeof.(total_specific_enthalpy.(ts, e_tot)) == typeof.(e_int)
-        @test typeof.(moist_static_energy.(ts, e_pot)) == typeof.(e_int)
-        @test typeof.(getproperty.(PhasePartition.(ts), :tot)) == typeof.(e_int)
+        @test typeof.(total_specific_enthalpy.(param_set, ts, e_tot)) ==
+              typeof.(e_int)
+        @test typeof.(moist_static_energy.(param_set, ts, e_pot)) ==
+              typeof.(e_int)
+        @test typeof.(getproperty.(PhasePartition.(param_set, ts), :tot)) ==
+              typeof.(e_int)
     end
 
 end
@@ -1282,70 +1347,159 @@ end
     ts_dry = PhaseDry(param_set, first(e_int), first(ρ))
     ts_eq =
         PhaseEquil_ρeq(param_set, first(ρ), first(e_int), typeof(first(ρ))(0))
-    @test PhasePartition(ts_eq).tot ≈ PhasePartition(ts_dry).tot
-    @test PhasePartition(ts_eq).liq ≈ PhasePartition(ts_dry).liq
-    @test PhasePartition(ts_eq).ice ≈ PhasePartition(ts_dry).ice
+    @test PhasePartition(param_set, ts_eq).tot ≈
+          PhasePartition(param_set, ts_dry).tot
+    @test PhasePartition(param_set, ts_eq).liq ≈
+          PhasePartition(param_set, ts_dry).liq
+    @test PhasePartition(param_set, ts_eq).ice ≈
+          PhasePartition(param_set, ts_dry).ice
 
-    @test mixing_ratios(ts_eq).tot ≈ mixing_ratios(ts_dry).tot
-    @test mixing_ratios(ts_eq).liq ≈ mixing_ratios(ts_dry).liq
-    @test mixing_ratios(ts_eq).ice ≈ mixing_ratios(ts_dry).ice
+    @test mixing_ratios(param_set, ts_eq).tot ≈
+          mixing_ratios(param_set, ts_dry).tot
+    @test mixing_ratios(param_set, ts_eq).liq ≈
+          mixing_ratios(param_set, ts_dry).liq
+    @test mixing_ratios(param_set, ts_eq).ice ≈
+          mixing_ratios(param_set, ts_dry).ice
 
     ts_dry = PhaseDry.(param_set, e_int, ρ)
     ts_eq = PhaseEquil_ρeq.(param_set, ρ, e_int, q_tot .* 0)
 
-    @test all(gas_constant_air.(ts_eq) .≈ gas_constant_air.(ts_dry))
-    @test all(relative_humidity.(ts_eq) .≈ relative_humidity.(ts_dry))
-    @test all(air_pressure.(ts_eq) .≈ air_pressure.(ts_dry))
-    @test all(air_density.(ts_eq) .≈ air_density.(ts_dry))
-    @test all(specific_volume.(ts_eq) .≈ specific_volume.(ts_dry))
     @test all(
-        total_specific_humidity.(ts_eq) .≈ total_specific_humidity.(ts_dry),
+        gas_constant_air.(param_set, ts_eq) .≈
+        gas_constant_air.(param_set, ts_dry),
     )
     @test all(
-        liquid_specific_humidity.(ts_eq) .≈ liquid_specific_humidity.(ts_dry),
+        relative_humidity.(param_set, ts_eq) .≈
+        relative_humidity.(param_set, ts_dry),
     )
-    @test all(ice_specific_humidity.(ts_eq) .≈ ice_specific_humidity.(ts_dry))
-    @test all(cp_m.(ts_eq) .≈ cp_m.(ts_dry))
-    @test all(cv_m.(ts_eq) .≈ cv_m.(ts_dry))
-    @test all(air_temperature.(ts_eq) .≈ air_temperature.(ts_dry))
-    @test all(internal_energy.(ts_eq) .≈ internal_energy.(ts_dry))
-    @test all(internal_energy_sat.(ts_eq) .≈ internal_energy_sat.(ts_dry))
-    @test all(internal_energy_dry.(ts_eq) .≈ internal_energy_dry.(ts_dry))
-    @test all(internal_energy_vapor.(ts_eq) .≈ internal_energy_vapor.(ts_dry))
-    @test all(internal_energy_liquid.(ts_eq) .≈ internal_energy_liquid.(ts_dry))
-    @test all(internal_energy_ice.(ts_eq) .≈ internal_energy_ice.(ts_dry))
-    @test all(soundspeed_air.(ts_eq) .≈ soundspeed_air.(ts_dry))
-    @test all(supersaturation.(ts_eq, Ice()) .≈ supersaturation.(ts_dry, Ice()))
     @test all(
-        supersaturation.(ts_eq, Liquid()) .≈ supersaturation.(ts_dry, Liquid()),
+        air_pressure.(param_set, ts_eq) .≈ air_pressure.(param_set, ts_dry),
     )
-    @test all(latent_heat_vapor.(ts_eq) .≈ latent_heat_vapor.(ts_dry))
-    @test all(latent_heat_sublim.(ts_eq) .≈ latent_heat_sublim.(ts_dry))
-    @test all(latent_heat_fusion.(ts_eq) .≈ latent_heat_fusion.(ts_dry))
-    @test all(q_vap_saturation.(ts_eq) .≈ q_vap_saturation.(ts_dry))
+    @test all(air_density.(param_set, ts_eq) .≈ air_density.(param_set, ts_dry))
     @test all(
-        q_vap_saturation_liquid.(ts_eq) .≈ q_vap_saturation_liquid.(ts_dry),
+        specific_volume.(param_set, ts_eq) .≈
+        specific_volume.(param_set, ts_dry),
     )
-    @test all(q_vap_saturation_ice.(ts_eq) .≈ q_vap_saturation_ice.(ts_dry))
-    @test all(saturation_excess.(ts_eq) .≈ saturation_excess.(ts_dry))
-    @test all(liquid_fraction.(ts_eq) .≈ liquid_fraction.(ts_dry))
-    @test all(liquid_ice_pottemp.(ts_eq) .≈ liquid_ice_pottemp.(ts_dry))
-    @test all(dry_pottemp.(ts_eq) .≈ dry_pottemp.(ts_dry))
-    @test all(virtual_pottemp.(ts_eq) .≈ virtual_pottemp.(ts_dry))
-    @test all(specific_entropy.(ts_eq) .≈ specific_entropy.(ts_dry))
-    @test all(liquid_ice_pottemp_sat.(ts_eq) .≈ liquid_ice_pottemp_sat.(ts_dry))
-    @test all(exner.(ts_eq) .≈ exner.(ts_dry))
+    @test all(
+        total_specific_humidity.(param_set, ts_eq) .≈
+        total_specific_humidity.(param_set, ts_dry),
+    )
+    @test all(
+        liquid_specific_humidity.(param_set, ts_eq) .≈
+        liquid_specific_humidity.(param_set, ts_dry),
+    )
+    @test all(
+        ice_specific_humidity.(param_set, ts_eq) .≈
+        ice_specific_humidity.(param_set, ts_dry),
+    )
+    @test all(cp_m.(param_set, ts_eq) .≈ cp_m.(param_set, ts_dry))
+    @test all(cv_m.(param_set, ts_eq) .≈ cv_m.(param_set, ts_dry))
+    @test all(
+        air_temperature.(param_set, ts_eq) .≈
+        air_temperature.(param_set, ts_dry),
+    )
+    @test all(
+        internal_energy.(param_set, ts_eq) .≈
+        internal_energy.(param_set, ts_dry),
+    )
+    @test all(
+        internal_energy_sat.(param_set, ts_eq) .≈
+        internal_energy_sat.(param_set, ts_dry),
+    )
+    @test all(
+        internal_energy_dry.(param_set, ts_eq) .≈
+        internal_energy_dry.(param_set, ts_dry),
+    )
+    @test all(
+        internal_energy_vapor.(param_set, ts_eq) .≈
+        internal_energy_vapor.(param_set, ts_dry),
+    )
+    @test all(
+        internal_energy_liquid.(param_set, ts_eq) .≈
+        internal_energy_liquid.(param_set, ts_dry),
+    )
+    @test all(
+        internal_energy_ice.(param_set, ts_eq) .≈
+        internal_energy_ice.(param_set, ts_dry),
+    )
+    @test all(
+        soundspeed_air.(param_set, ts_eq) .≈ soundspeed_air.(param_set, ts_dry),
+    )
+    @test all(
+        supersaturation.(param_set, ts_eq, Ice()) .≈
+        supersaturation.(param_set, ts_dry, Ice()),
+    )
+    @test all(
+        supersaturation.(param_set, ts_eq, Liquid()) .≈
+        supersaturation.(param_set, ts_dry, Liquid()),
+    )
+    @test all(
+        latent_heat_vapor.(param_set, ts_eq) .≈
+        latent_heat_vapor.(param_set, ts_dry),
+    )
+    @test all(
+        latent_heat_sublim.(param_set, ts_eq) .≈
+        latent_heat_sublim.(param_set, ts_dry),
+    )
+    @test all(
+        latent_heat_fusion.(param_set, ts_eq) .≈
+        latent_heat_fusion.(param_set, ts_dry),
+    )
+    @test all(
+        q_vap_saturation.(param_set, ts_eq) .≈
+        q_vap_saturation.(param_set, ts_dry),
+    )
+    @test all(
+        q_vap_saturation_liquid.(param_set, ts_eq) .≈
+        q_vap_saturation_liquid.(param_set, ts_dry),
+    )
+    @test all(
+        q_vap_saturation_ice.(param_set, ts_eq) .≈
+        q_vap_saturation_ice.(param_set, ts_dry),
+    )
+    @test all(
+        saturation_excess.(param_set, ts_eq) .≈
+        saturation_excess.(param_set, ts_dry),
+    )
+    @test all(
+        liquid_fraction.(param_set, ts_eq) .≈
+        liquid_fraction.(param_set, ts_dry),
+    )
+    @test all(
+        liquid_ice_pottemp.(param_set, ts_eq) .≈
+        liquid_ice_pottemp.(param_set, ts_dry),
+    )
+    @test all(dry_pottemp.(param_set, ts_eq) .≈ dry_pottemp.(param_set, ts_dry))
+    @test all(
+        virtual_pottemp.(param_set, ts_eq) .≈
+        virtual_pottemp.(param_set, ts_dry),
+    )
+    @test all(
+        specific_entropy.(param_set, ts_eq) .≈
+        specific_entropy.(param_set, ts_dry),
+    )
+    @test all(
+        liquid_ice_pottemp_sat.(param_set, ts_eq) .≈
+        liquid_ice_pottemp_sat.(param_set, ts_dry),
+    )
+    @test all(exner.(param_set, ts_eq) .≈ exner.(param_set, ts_dry))
 
     @test all(
-        saturation_vapor_pressure.(ts_eq, Ice()) .≈
-        saturation_vapor_pressure.(ts_dry, Ice()),
+        saturation_vapor_pressure.(param_set, ts_eq, Ice()) .≈
+        saturation_vapor_pressure.(param_set, ts_dry, Ice()),
     )
     @test all(
-        saturation_vapor_pressure.(ts_eq, Liquid()) .≈
-        saturation_vapor_pressure.(ts_dry, Liquid()),
+        saturation_vapor_pressure.(param_set, ts_eq, Liquid()) .≈
+        saturation_vapor_pressure.(param_set, ts_dry, Liquid()),
     )
-    @test all(first.(gas_constants.(ts_eq)) ≈ first.(gas_constants.(ts_dry)))
-    @test all(last.(gas_constants.(ts_eq)) ≈ last.(gas_constants.(ts_dry)))
+    @test all(
+        first.(gas_constants.(param_set, ts_eq)) ≈
+        first.(gas_constants.(param_set, ts_dry)),
+    )
+    @test all(
+        last.(gas_constants.(param_set, ts_eq)) ≈
+        last.(gas_constants.(param_set, ts_dry)),
+    )
 
 end
 

--- a/test/runtests_gpu.jl
+++ b/test/runtests_gpu.jl
@@ -51,7 +51,7 @@ end
     @inbounds begin
 
         ts = TD.PhaseEquil_ρeq(param_set, FT(ρ[i]), FT(e_int[i]), FT(q_tot[i]))
-        dst[1, i] = TD.air_temperature(ts)
+        dst[1, i] = TD.air_temperature(param_set, ts)
 
         ts_ρpq = TD.PhaseEquil_ρpq(
             param_set,
@@ -62,7 +62,7 @@ end
             100,
             RS.RegulaFalsiMethod,
         )
-        dst[2, i] = TD.air_temperature(ts_ρpq)
+        dst[2, i] = TD.air_temperature(param_set, ts_ρpq)
     end
 end
 
@@ -113,7 +113,7 @@ convert_profile_set(ps::TD.TestedProfiles.ProfileSet, ArrayType, slice) =
 
     ts_correct =
         TD.PhaseEquil_ρeq.(param_set, Array(ρ), Array(e_int), Array(q_tot))
-    @test all(Array(d_dst)[1, :] .≈ TD.air_temperature.(ts_correct))
+    @test all(Array(d_dst)[1, :] .≈ TD.air_temperature.(param_set, ts_correct))
 
     ts_correct =
         TD.PhaseEquil_ρpq.(
@@ -125,6 +125,6 @@ convert_profile_set(ps::TD.TestedProfiles.ProfileSet, ArrayType, slice) =
             100,
             RS.RegulaFalsiMethod,
         )
-    @test all(Array(d_dst)[2, :] .≈ TD.air_temperature.(ts_correct))
+    @test all(Array(d_dst)[2, :] .≈ TD.air_temperature.(param_set, ts_correct))
 
 end


### PR DESCRIPTION
This PR removes the `param_set` cache from thermodynamic states. This is a pretty big API / breaking change, however, it will allow us to capture thermodynamic states, which seems like it will be both necessary and handy (we'll be able to make Thermo state fields, and hopefully remove several aux fields as a result).

I think that this PR and #91 will help shrink #83 into a more isolated PR.

@trontrytel, any idea on the blast radius this will have in Microphysics?