### PR TITLE
add a specific enthalpy route for thermodynamic state

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -25,6 +25,7 @@ PhaseEquil_ρTq
 PhaseEquil_pTq
 PhaseEquil_pθq
 PhaseEquil_peq
+PhaseEquil_phq
 PhaseEquil_ρθq
 PhaseEquil_ρpq
 PhaseNonEquil

--- a/src/TestedProfiles.jl
+++ b/src/TestedProfiles.jl
@@ -32,6 +32,7 @@ struct ProfileSet{AFT, QPT, PT}
     p::AFT          # Pressure
     RS::AFT         # Relative saturation
     e_int::AFT      # Internal energy
+    h::AFT          # Specific enthalpy
     ρ::AFT          # Density
     θ_liq_ice::AFT  # Liquid Ice Potential temperature
     q_tot::AFT      # Total specific humidity
@@ -55,6 +56,7 @@ function Base.iterate(ps::ProfileSet, state = 1)
         p = ps.p[state],
         RS = ps.RS[state],
         e_int = ps.e_int[state],
+        h = ps.h[state],
         ρ = ps.ρ[state],
         θ_liq_ice = ps.θ_liq_ice[state],
         q_tot = ps.q_tot[state],
@@ -178,6 +180,7 @@ function PhaseDryProfiles(param_set::APS, ::Type{ArrayType}) where {ArrayType}
     fill!(q_tot, 0)
     q_pt = TD.PhasePartition_equil.(param_set, T, ρ, q_tot, phase_type)
     e_int = TD.internal_energy.(param_set, T, q_pt)
+    h = TD.specific_enthalpy.(param_set, T, q_pt)
     θ_liq_ice = TD.liquid_ice_pottemp.(param_set, T, ρ, q_pt)
     q_liq = getproperty.(q_pt, :liq)
     q_ice = getproperty.(q_pt, :ice)
@@ -196,6 +199,7 @@ function PhaseDryProfiles(param_set::APS, ::Type{ArrayType}) where {ArrayType}
         p,
         RS,
         e_int,
+        h,
         ρ,
         θ_liq_ice,
         q_tot,
@@ -250,6 +254,7 @@ function PhaseEquilProfiles(param_set::APS, ::Type{ArrayType}) where {ArrayType}
     p = TD.air_pressure.(Ref(param_set), T, ρ, q_pt)
 
     e_int = TD.internal_energy.(Ref(param_set), T, q_pt)
+    h = TD.specific_enthalpy.(Ref(param_set), T, q_pt)
     θ_liq_ice = TD.liquid_ice_pottemp.(Ref(param_set), T, ρ, q_pt)
     RH = TD.relative_humidity.(Ref(param_set), T, p, Ref(phase_type), q_pt)
     e_pot = grav * z
@@ -265,6 +270,7 @@ function PhaseEquilProfiles(param_set::APS, ::Type{ArrayType}) where {ArrayType}
         p,
         RS,
         e_int,
+        h,
         ρ,
         θ_liq_ice,
         q_tot,

--- a/src/relations.jl
+++ b/src/relations.jl
@@ -348,7 +348,7 @@ end
 
 ## YAIR check this
 """
-    air_temperature(param_set, h, q::PhasePartition)
+    air_temperature_from_enthalpy(param_set, h, q::PhasePartition)
 
 The air temperature, where
 

--- a/src/relations.jl
+++ b/src/relations.jl
@@ -1655,7 +1655,7 @@ function saturation_adjustment_given_phq(
     if !sol.converged
         if print_warning()
             KA.@print("-----------------------------------------\n")
-            KA.@print("maxiter reached in saturation_adjustment_peq:\n")
+            KA.@print("maxiter reached in saturation_adjustment_phq:\n")
             print_numerical_method(sat_adjust_method)
             KA.@print(", h=", h)
             KA.@print(", p=", p)

--- a/src/relations.jl
+++ b/src/relations.jl
@@ -1640,7 +1640,7 @@ function saturation_adjustment_given_phq(
     end
     sol = RS.find_zero(
         T -> h_sat(T) - h,
-        sa_numerical_method_peq(
+        sa_numerical_method_phq(
             sat_adjust_method,
             param_set,
             p,

--- a/src/relations.jl
+++ b/src/relations.jl
@@ -369,7 +369,7 @@ function air_temperature_from_enthalpy(
     LH_f0::FT = ICP.LH_f0(param_set)
     e_int_i0::FT = ICP.e_int_i0(param_set)
     q_vap::FT = vapor_specific_humidity(q)
-    return (h + cp_m_*T_0 - q_vap*LH_v0} + q_i*LH_f0 - (FT(1-q.tot)*R_d*T_0)/cp_m_
+    return (h + cp_m_*T_0 - q_vap*LH_v0) + q_i*LH_f0 - ((1-q.tot)*R_d*T_0)/cp_m_
 end
 
 """

--- a/src/states.jl
+++ b/src/states.jl
@@ -5,6 +5,7 @@ export ThermodynamicState,
     PhaseDry_ρT,
     PhaseDry_pT,
     PhaseDry_pe,
+    PhaseDry_ph,
     PhaseDry_ρθ,
     PhaseDry_pθ,
     PhaseDry_ρp,
@@ -13,6 +14,7 @@ export ThermodynamicState,
     PhaseEquil_ρTq,
     PhaseEquil_pTq,
     PhaseEquil_peq,
+    PhaseEquil_phq,
     PhaseEquil_ρθq,
     PhaseEquil_pθq,
     PhaseEquil_ρpq,
@@ -22,6 +24,7 @@ export ThermodynamicState,
     PhaseNonEquil_ρθq,
     PhaseNonEquil_pθq,
     PhaseNonEquil_peq,
+    PhaseNonEquil_phq,
     PhaseNonEquil_ρpq
 
 """
@@ -38,8 +41,6 @@ abstract type AbstractPhaseDry{FT} <: ThermodynamicState{FT} end
 abstract type AbstractPhaseEquil{FT} <: ThermodynamicState{FT} end
 abstract type AbstractPhaseNonEquil{FT} <: ThermodynamicState{FT} end
 
-Base.eltype(::ThermodynamicState{FT}) where {FT} = FT
-
 """
     PhasePartition
 
@@ -48,7 +49,7 @@ Represents the mass fractions of the moist air mixture.
 # Constructors
 
     PhasePartition(q_tot::Real[, q_liq::Real[, q_ice::Real]])
-    PhasePartition(param_set::APS, ts::ThermodynamicState)
+    PhasePartition(ts::ThermodynamicState)
 
 See also [`PhasePartition_equil`](@ref)
 
@@ -96,13 +97,16 @@ A dry thermodynamic state (`q_tot = 0`).
 
 $(DocStringExtensions.FIELDS)
 """
-struct PhaseDry{FT} <: AbstractPhaseDry{FT}
+struct PhaseDry{FT, PS} <: AbstractPhaseDry{FT}
+    "parameter set, used to dispatch planet parameter function calls"
+    param_set::PS
     "internal energy"
     e_int::FT
     "density of dry air"
     ρ::FT
 end
-PhaseDry(param_set::APS, e_int::FT, ρ::FT) where {FT} = PhaseDry{FT}(e_int, ρ)
+PhaseDry(param_set::APS, e_int::FT, ρ::FT) where {FT} =
+    PhaseDry{FT, typeof(param_set)}(param_set, e_int, ρ)
 
 """
     PhaseDry_pT(param_set, p, T)
@@ -116,7 +120,7 @@ Constructs a [`PhaseDry`](@ref) thermodynamic state from:
 function PhaseDry_pT(param_set::APS, p::FT, T::FT) where {FT <: Real}
     e_int = internal_energy(param_set, T)
     ρ = air_density(param_set, T, p)
-    return PhaseDry{FT}(e_int, ρ)
+    return PhaseDry{FT, typeof(param_set)}(param_set, e_int, ρ)
 end
 
 """
@@ -131,7 +135,23 @@ Constructs a [`PhaseDry`](@ref) thermodynamic state from:
 function PhaseDry_pe(param_set::APS, p::FT, e_int::FT) where {FT <: Real}
     T = air_temperature(param_set, e_int)
     ρ = air_density(param_set, T, p)
-    return PhaseDry{FT}(e_int, ρ)
+    return PhaseDry{FT, typeof(param_set)}(param_set, e_int, ρ)
+end
+
+"""
+    PhaseDry_ph(param_set, p, h)
+
+Constructs a [`PhaseDry`](@ref) thermodynamic state from:
+
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
+ - `p` pressure
+ - `h` specific enthalpy
+"""
+function PhaseDry_pe(param_set::APS, p::FT, h::FT) where {FT <: Real}
+    T = air_temperature_from_enthalpy(param_set, h)
+    ρ = air_density(param_set, T, p)
+    e_int = internal_energy(param_set, ts)
+    return PhaseDry{FT, typeof(param_set)}(param_set, e_int, ρ)
 end
 
 """
@@ -146,7 +166,7 @@ Constructs a [`PhaseDry`](@ref) thermodynamic state from:
 function PhaseDry_ρθ(param_set::APS, ρ::FT, θ_dry::FT) where {FT <: Real}
     T = air_temperature_given_ρθq(param_set, ρ, θ_dry)
     e_int = internal_energy(param_set, T)
-    return PhaseDry{FT}(e_int, ρ)
+    return PhaseDry{FT, typeof(param_set)}(param_set, e_int, ρ)
 end
 
 """
@@ -162,7 +182,7 @@ function PhaseDry_pθ(param_set::APS, p::FT, θ_dry::FT) where {FT <: Real}
     T = exner_given_pressure(param_set, p) * θ_dry
     e_int = internal_energy(param_set, T)
     ρ = air_density(param_set, T, p)
-    return PhaseDry{FT}(e_int, ρ)
+    return PhaseDry{FT, typeof(param_set)}(param_set, e_int, ρ)
 end
 
 """
@@ -176,7 +196,7 @@ Constructs a [`PhaseDry`](@ref) thermodynamic state from:
 """
 function PhaseDry_ρT(param_set::APS, ρ::FT, T::FT) where {FT <: Real}
     e_int = internal_energy(param_set, T)
-    return PhaseDry{FT}(e_int, ρ)
+    return PhaseDry{FT, typeof(param_set)}(param_set, e_int, ρ)
 end
 
 """
@@ -191,7 +211,7 @@ Constructs a [`PhaseDry`](@ref) thermodynamic state from:
 function PhaseDry_ρp(param_set::APS, ρ::FT, p::FT) where {FT <: Real}
     T = air_temperature_from_ideal_gas_law(param_set, p, ρ)
     e_int = internal_energy(param_set, T)
-    return PhaseDry{FT}(e_int, ρ)
+    return PhaseDry{FT, typeof(param_set)}(param_set, e_int, ρ)
 end
 
 #####
@@ -212,7 +232,9 @@ may be needed).
 
 $(DocStringExtensions.FIELDS)
 """
-struct PhaseEquil{FT} <: AbstractPhaseEquil{FT}
+struct PhaseEquil{FT, PS} <: AbstractPhaseEquil{FT}
+    "parameter set, used to dispatch planet parameter function calls"
+    param_set::PS
     "density of air (potentially moist)"
     ρ::FT
     "air pressure"
@@ -250,7 +272,7 @@ function PhaseEquil_ρeq(
 ) where {FT <: Real, sat_adjust_method, IT <: ITERTYPE, FTT <: TOLTYPE(FT)}
     maxiter === nothing && (maxiter = 8)
     temperature_tol === nothing && (temperature_tol = FT(1e-1))
-    phase_type = PhaseEquil{FT}
+    phase_type = PhaseEquil{FT, typeof(param_set)}
     q_tot_safe = clamp(q_tot, FT(0), FT(1))
     T = saturation_adjustment(
         sat_adjust_method,
@@ -264,7 +286,14 @@ function PhaseEquil_ρeq(
     )
     q_pt = PhasePartition_equil(param_set, T, ρ, q_tot_safe, phase_type)
     p = air_pressure(param_set, T, ρ, q_pt)
-    return PhaseEquil{FT}(ρ, p, e_int, q_tot_safe, T)
+    return PhaseEquil{FT, typeof(param_set)}(
+        param_set,
+        ρ,
+        p,
+        e_int,
+        q_tot_safe,
+        T,
+    )
 end
 
 # Convenience method for comparing Numerical
@@ -313,7 +342,7 @@ function PhaseEquil_ρθq(
 ) where {FT <: Real, IT <: ITERTYPE, FTT <: TOLTYPE(FT)}
     maxiter === nothing && (maxiter = 36)
     temperature_tol === nothing && (temperature_tol = FT(1e-1))
-    phase_type = PhaseEquil{FT}
+    phase_type = PhaseEquil{FT, typeof(param_set)}
     tol = RS.ResidualTolerance(temperature_tol)
     T = saturation_adjustment_given_ρθq(
         param_set,
@@ -327,7 +356,7 @@ function PhaseEquil_ρθq(
     q_pt = PhasePartition_equil(param_set, T, ρ, q_tot, phase_type)
     p = air_pressure(param_set, T, ρ, q_pt)
     e_int = internal_energy(param_set, T, q_pt)
-    return PhaseEquil{FT}(ρ, p, e_int, q_tot, T)
+    return PhaseEquil{FT, typeof(param_set)}(param_set, ρ, p, e_int, q_tot, T)
 end
 
 """
@@ -346,11 +375,11 @@ function PhaseEquil_ρTq(
     T::FT,
     q_tot::FT,
 ) where {FT <: Real}
-    phase_type = PhaseEquil{FT}
+    phase_type = PhaseEquil{FT, typeof(param_set)}
     q_pt = PhasePartition_equil(param_set, T, ρ, q_tot, phase_type)
     p = air_pressure(param_set, T, ρ, q_pt)
     e_int = internal_energy(param_set, T, q_pt)
-    return PhaseEquil{FT}(ρ, p, e_int, q_tot, T)
+    return PhaseEquil{FT, typeof(param_set)}(param_set, ρ, p, e_int, q_tot, T)
 end
 
 """
@@ -369,22 +398,29 @@ function PhaseEquil_pTq(
     T::FT,
     q_tot::FT,
 ) where {FT <: Real}
-    phase_type = PhaseEquil{FT}
+    phase_type = PhaseEquil{FT, typeof(param_set)}
     q_tot_safe = clamp(q_tot, FT(0), FT(1))
     q_pt = PhasePartition_equil_given_p(param_set, T, p, q_tot_safe, phase_type)
     ρ = air_density(param_set, T, p, q_pt)
     e_int = internal_energy(param_set, T, q_pt)
-    return PhaseEquil{FT}(ρ, p, e_int, q_tot_safe, T)
+    return PhaseEquil{FT, typeof(param_set)}(
+        param_set,
+        ρ,
+        p,
+        e_int,
+        q_tot_safe,
+        T,
+    )
 end
 
 """
     PhaseEquil_peq(param_set, p, e_int, q_tot)
 
-Constructs a [`PhaseEquil`](@ref) thermodynamic state from temperature.
+Constructs a [`PhaseEquil`](@ref) thermodynamic state from internal energy.
 
  - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `p` pressure
- - `e_int` temperature
+ - `e_int` internal energy
  - `q_tot` total specific humidity
 """
 function PhaseEquil_peq(
@@ -398,7 +434,7 @@ function PhaseEquil_peq(
 ) where {FT <: Real, sat_adjust_method, IT <: ITERTYPE, FTT <: TOLTYPE(FT)}
     maxiter === nothing && (maxiter = 40)
     temperature_tol === nothing && (temperature_tol = FT(1e-2))
-    phase_type = PhaseEquil{FT}
+    phase_type = PhaseEquil{FT, typeof(param_set)}
     q_tot_safe = clamp(q_tot, FT(0), FT(1))
     T = saturation_adjustment_given_peq(
         sat_adjust_method,
@@ -412,7 +448,60 @@ function PhaseEquil_peq(
     )
     q_pt = PhasePartition_equil_given_p(param_set, T, p, q_tot_safe, phase_type)
     ρ = air_density(param_set, T, p, q_pt)
-    return PhaseEquil{FT}(ρ, p, e_int, q_tot_safe, T)
+    return PhaseEquil{FT, typeof(param_set)}(
+        param_set,
+        ρ,
+        p,
+        e_int,
+        q_tot_safe,
+        T,
+    )
+end
+
+"""
+    PhaseEquil_phq(param_set, p, e_int, q_tot)
+
+Constructs a [`PhaseEquil`](@ref) thermodynamic state from:
+
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
+ - `p` pressure
+ - `e_int` specific enthalpy
+ - `q_tot` total specific humidity
+"""
+function PhaseEquil_phq(
+    param_set::APS,
+    p::FT,
+    h::FT,
+    q_tot::FT,
+    maxiter::IT = nothing,
+    temperature_tol::FTT = nothing,
+    ::Type{sat_adjust_method} = RS.SecantMethod,
+) where {FT <: Real, sat_adjust_method, IT <: ITERTYPE, FTT <: TOLTYPE(FT)}
+    maxiter === nothing && (maxiter = 40)
+    temperature_tol === nothing && (temperature_tol = FT(1e-2))
+    phase_type = PhaseEquil{FT, typeof(param_set)}
+    q_tot_safe = clamp(q_tot, FT(0), FT(1))
+    T = saturation_adjustment_given_phq(
+        sat_adjust_method,
+        param_set,
+        p,
+        h,
+        q_tot_safe,
+        phase_type,
+        maxiter,
+        temperature_tol,
+    )
+    q_pt = PhasePartition_equil_given_p(param_set, T, p, q_tot_safe, phase_type)
+    ρ = air_density(param_set, T, p, q_pt)
+    e_int = internal_energy(param_set, ts)
+    return PhaseEquil{FT, typeof(param_set)}(
+        param_set,
+        ρ,
+        p,
+        e_int,
+        q_tot_safe,
+        T,
+    )
 end
 
 """
@@ -439,7 +528,7 @@ function PhaseEquil_ρpq(
     ::Type{sat_adjust_method} = RS.NewtonsMethodAD,
 ) where {FT <: Real, sat_adjust_method}
 
-    phase_type = PhaseEquil{FT}
+    phase_type = PhaseEquil{FT, typeof(param_set)}
     if perform_sat_adjust
         T = saturation_adjustment_ρpq(
             sat_adjust_method,
@@ -457,7 +546,7 @@ function PhaseEquil_ρpq(
         T = air_temperature_from_ideal_gas_law(param_set, p, ρ, q_pt)
         e_int = internal_energy(param_set, T, q_pt)
     end
-    return PhaseEquil{FT}(ρ, p, e_int, q_tot, T)
+    return PhaseEquil{FT, typeof(param_set)}(param_set, ρ, p, e_int, q_tot, T)
 end
 
 
@@ -485,7 +574,7 @@ function PhaseEquil_pθq(
 ) where {FT <: Real, IT <: ITERTYPE, FTT <: TOLTYPE(FT), sat_adjust_method}
     maxiter === nothing && (maxiter = 50)
     temperature_tol === nothing && (temperature_tol = FT(1e-3))
-    phase_type = PhaseEquil{FT}
+    phase_type = PhaseEquil{FT, typeof(param_set)}
     q_tot_safe = clamp(q_tot, FT(0), FT(1))
     T = saturation_adjustment_given_pθq(
         sat_adjust_method,
@@ -500,7 +589,14 @@ function PhaseEquil_pθq(
     q_pt = PhasePartition_equil_given_p(param_set, T, p, q_tot_safe, phase_type)
     ρ = air_density(param_set, T, p, q_pt)
     e_int = internal_energy(param_set, T, q_pt)
-    return PhaseEquil{FT}(ρ, p, e_int, q_tot_safe, T)
+    return PhaseEquil{FT, typeof(param_set)}(
+        param_set,
+        ρ,
+        p,
+        e_int,
+        q_tot_safe,
+        T,
+    )
 end
 
 
@@ -523,7 +619,9 @@ be computed directly).
 $(DocStringExtensions.FIELDS)
 
 """
-struct PhaseNonEquil{FT} <: AbstractPhaseNonEquil{FT}
+struct PhaseNonEquil{FT, PS} <: AbstractPhaseNonEquil{FT}
+    "parameter set, used to dispatch planet parameter function calls"
+    param_set::PS
     "internal energy"
     e_int::FT
     "density of air (potentially moist)"
@@ -537,7 +635,7 @@ function PhaseNonEquil(
     ρ::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
 ) where {FT}
-    return PhaseNonEquil{FT}(e_int, ρ, q)
+    return PhaseNonEquil{FT, typeof(param_set)}(param_set, e_int, ρ, q)
 end
 
 """
@@ -557,7 +655,7 @@ function PhaseNonEquil_ρTq(
     q_pt::PhasePartition{FT},
 ) where {FT <: Real}
     e_int = internal_energy(param_set, T, q_pt)
-    return PhaseNonEquil{FT}(e_int, ρ, q_pt)
+    return PhaseNonEquil{FT, typeof(param_set)}(param_set, e_int, ρ, q_pt)
 end
 
 """
@@ -581,7 +679,7 @@ function PhaseNonEquil_ρθq(
     maxiter::Int = 10,
     potential_temperature_tol::FT = FT(1e-2),
 ) where {FT <: Real}
-    phase_type = PhaseNonEquil{FT}
+    phase_type = PhaseNonEquil{FT, typeof(param_set)}
     tol = RS.ResidualTolerance(potential_temperature_tol)
     T = air_temperature_given_ρθq_nonlinear(
         param_set,
@@ -592,7 +690,7 @@ function PhaseNonEquil_ρθq(
         q_pt,
     )
     e_int = internal_energy(param_set, T, q_pt)
-    return PhaseNonEquil{FT}(e_int, ρ, q_pt)
+    return PhaseNonEquil{FT, typeof(param_set)}(param_set, e_int, ρ, q_pt)
 end
 
 """
@@ -614,7 +712,7 @@ function PhaseNonEquil_pθq(
     T = air_temperature_given_pθq(param_set, p, θ_liq_ice, q_pt)
     ρ = air_density(param_set, T, p, q_pt)
     e_int = internal_energy(param_set, T, q_pt)
-    return PhaseNonEquil{FT}(e_int, ρ, q_pt)
+    return PhaseNonEquil{FT, typeof(param_set)}(param_set, e_int, ρ, q_pt)
 end
 
 """
@@ -635,7 +733,7 @@ function PhaseNonEquil_pTq(
 ) where {FT <: Real}
     ρ = air_density(param_set, T, p, q_pt)
     e_int = internal_energy(param_set, T, q_pt)
-    return PhaseNonEquil{FT}(e_int, ρ, q_pt)
+    return PhaseNonEquil{FT, typeof(param_set)}(param_set, e_int, ρ, q_pt)
 end
 
 """
@@ -656,7 +754,29 @@ function PhaseNonEquil_peq(
 ) where {FT <: Real}
     T = air_temperature(param_set, e_int, q_pt)
     ρ = air_density(param_set, T, p, q_pt)
-    return PhaseNonEquil{FT}(e_int, ρ, q_pt)
+    return PhaseNonEquil{FT, typeof(param_set)}(param_set, e_int, ρ, q_pt)
+end
+
+"""
+    PhaseNonEquil_phq(param_set, p, h, q_pt)
+
+Constructs a [`PhaseNonEquil`](@ref) thermodynamic state from:
+
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
+ - `p` pressure
+ - `h` specific enthalpy
+ - `q_pt` phase partition
+"""
+function PhaseNonEquil_phq(
+    param_set::APS,
+    p::FT,
+    h::FT,
+    q_pt::PhasePartition{FT},
+) where {FT <: Real}
+    T = air_temperature_from_enthalpy(param_set, h, q_pt)
+    ρ = air_density(param_set, T, p, q_pt)
+    e_int = internal_energy(param_set, ts)
+    return PhaseNonEquil{FT, typeof(param_set)}(param_set, e_int, ρ, q_pt)
 end
 
 """
@@ -677,5 +797,5 @@ function PhaseNonEquil_ρpq(
 ) where {FT <: Real}
     T = air_temperature_from_ideal_gas_law(param_set, p, ρ, q_pt)
     e_int = internal_energy(param_set, T, q_pt)
-    return PhaseNonEquil{FT}(e_int, ρ, q_pt)
+    return PhaseNonEquil{FT, typeof(param_set)}(param_set, e_int, ρ, q_pt)
 end

--- a/test/relations.jl
+++ b/test/relations.jl
@@ -914,7 +914,7 @@ end
         _MSLP = FT(CPP.MSLP(param_set))
 
         profiles = TestedProfiles.PhaseDryProfiles(param_set, ArrayType)
-        @unpack T, p, e_int, ρ, θ_liq_ice, phase_type = profiles
+        @unpack T, p, e_int, h, ρ, θ_liq_ice, phase_type = profiles
         @unpack q_tot, q_liq, q_ice, q_pt, RH, e_kin, e_pot = profiles
 
         # PhaseDry
@@ -999,6 +999,13 @@ end
         )
         @test all(air_pressure.(param_set, ts_peq) .≈ p)
 
+        ts_phq = PhaseEquil_phq.(param_set, p, h, q_tot)
+        @test all(specific_enthalpy.(param_set, ts_peq) .≈ h)
+        @test all(
+            getproperty.(PhasePartition.(param_set, ts_phq), :tot) .≈ q_tot,
+        )
+        @test all(air_pressure.(param_set, ts_phq) .≈ p)
+
         ts_pθq = PhaseEquil_pθq.(param_set, p, θ_liq_ice, q_tot)
         @test all(air_pressure.(param_set, ts_pθq) .≈ p)
         # TODO: Run some tests to make sure that this decreses with
@@ -1051,6 +1058,11 @@ end
 
         ts = PhaseNonEquil_peq.(param_set, p, e_int, q_pt)
         @test all(internal_energy.(param_set, ts) .≈ e_int)
+        @test all(compare_moisture.(param_set, ts, q_pt))
+        @test all(air_pressure.(param_set, ts) .≈ p)
+
+        ts = PhaseNonEquil_phq.(param_set, p, h, q_pt)
+        @test all(specific_enthalpy.(param_set, ts) .≈ h)
         @test all(compare_moisture.(param_set, ts, q_pt))
         @test all(air_pressure.(param_set, ts) .≈ p)
 


### PR DESCRIPTION
This PR adds an enthalpy route to the thermodynamic state (Dry, PhaseEquil and PhaseNonEquil) 
It uses equation (2.15) in the design docs to compute the temperature from given enthalpy. 