### PR TITLE
Add dry constructor with given variable names

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -7,12 +7,19 @@ CurrentModule = Thermodynamics
 Thermodynamics
 ```
 
+## Thermodynamics Parameters
+
+```@docs
+Parameters.ThermodynamicsParameters
+```
+
 ## Thermodynamic State Constructors
 
 ```@docs
 PhasePartition
 ThermodynamicState
 PhaseDry
+PhaseDry_ρe
 PhaseDry_pT
 PhaseDry_pθ
 PhaseDry_pe

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -1,5 +1,7 @@
 module Parameters
 
+export ThermodynamicsParameters
+
 """
     ThermodynamicsParameters
 

--- a/src/states.jl
+++ b/src/states.jl
@@ -2,6 +2,7 @@ export PhasePartition
 # Thermodynamic states
 export ThermodynamicState,
     PhaseDry,
+    PhaseDry_ρe,
     PhaseDry_ρT,
     PhaseDry_pT,
     PhaseDry_pe,
@@ -100,12 +101,25 @@ A dry thermodynamic state (`q_tot = 0`).
 $(DocStringExtensions.FIELDS)
 """
 struct PhaseDry{FT} <: AbstractPhaseDry{FT}
+    # TODO: swap order of variables (breaking change)
     "internal energy"
     e_int::FT
     "density of dry air"
     ρ::FT
 end
 PhaseDry(param_set::APS, e_int::FT, ρ::FT) where {FT} = PhaseDry{FT}(e_int, ρ)
+
+"""
+    PhaseDry_ρe(param_set, ρ, e_int)
+
+A dry thermodynamic state (`q_tot = 0`) from
+
+ - `param_set` an [`ThermodynamicsParameters`](@ref Parameters.ThermodynamicsParameters) for more details
+ - `ρ`
+ - `e_int` internal energy
+"""
+PhaseDry_ρe(param_set::APS, ρ::FT, e_int::FT) where {FT} =
+    PhaseDry{FT}(e_int, ρ)
 
 """
     PhaseDry_pT(param_set, p, T)

--- a/test/relations.jl
+++ b/test/relations.jl
@@ -949,6 +949,13 @@ end
         )
         @test all(air_density.(param_set, ts_pT) .≈ ρ)
 
+        ts_ρe = PhaseDry_ρe.(param_set, ρ, e_int)
+        @test all(
+            internal_energy.(param_set, ts_ρe) .≈
+            internal_energy.(param_set, T),
+        )
+        @test all(air_density.(param_set, ts_ρe) .≈ ρ)
+
         θ_dry = dry_pottemp.(param_set, T, ρ)
         ts_pθ = PhaseDry_pθ.(param_set, p, θ_dry)
         @test all(


### PR DESCRIPTION
This PR adds an outer constructor `PhaseDry_ρe`, which is clearer and better follows our API.