### PR TITLE
Add job for monitoring flops

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -78,6 +78,15 @@ steps:
       slurm_ntasks: 1
     timeout_in_minutes: 60
 
+  - label: ":mag::rocket: Constructor flop measurements"
+    command:
+      - "julia --project=perf perf/flops.jl"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+    timeout_in_minutes: 60
+
   - label: ":mag::rocket: JET tests"
     command:
       - "julia --project=perf perf/jet.jl"

--- a/perf/Project.toml
+++ b/perf/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
+GFlops = "2ea8233c-34d4-5acc-88b4-02f326385bcc"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/perf/flops.jl
+++ b/perf/flops.jl
@@ -1,0 +1,66 @@
+include("common.jl")
+import GFlops
+import OrderedCollections
+import PrettyTables
+
+function total_flops(flops)
+    n_flops = Dict()
+    strip_nums(x) =
+        strip("$x", ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
+    for pn in strip_nums.(propertynames(flops))
+        n_flops[pn] = 0
+    end
+    for pn in propertynames(flops)
+        n_flops[strip_nums(pn)] += getproperty(flops, pn)
+    end
+    return n_flops
+end
+
+function summarize_flops(flops)
+    fnames = collect(keys(flops))
+    header = (["Function", keys(flops[first(fnames)])...],)
+    flops_neg = map(x -> flops[x]["neg"], fnames)
+    flops_add = map(x -> flops[x]["add"], fnames)
+    flops_sub = map(x -> flops[x]["sub"], fnames)
+    flops_muladd = map(x -> flops[x]["muladd"], fnames)
+    flops_fma = map(x -> flops[x]["fma"], fnames)
+    flops_mul = map(x -> flops[x]["mul"], fnames)
+    flops_div = map(x -> flops[x]["div"], fnames)
+    flops_rem = map(x -> flops[x]["rem"], fnames)
+    flops_sqrt = map(x -> flops[x]["sqrt"], fnames)
+    flops_abs = map(x -> flops[x]["abs"], fnames)
+    table_data = hcat(
+        fnames,
+        flops_neg,
+        flops_add,
+        flops_sub,
+        flops_muladd,
+        flops_fma,
+        flops_mul,
+        flops_div,
+        flops_rem,
+        flops_sqrt,
+        flops_abs,
+    )
+
+    PrettyTables.pretty_table(
+        table_data;
+        header,
+        crop = :none,
+        alignment = vcat(:l, repeat([:c], length(header[1]) - 1)),
+    )
+end
+
+#! format: off
+@testset "Thermodynamics - Flops" begin
+
+    flops = OrderedCollections.OrderedDict()
+    ts = TD.PhaseEquil_ρeq(param_set, ρ[1], e_int[1], q_tot[1])
+
+    flops["PhasePartition"] = total_flops(GFlops.@count_ops TD.PhasePartition($param_set, $ts))
+    flops["liquid_fraction"] = total_flops(GFlops.@count_ops TD.liquid_fraction($param_set, $ts))
+    flops["q_vap_saturation"] = total_flops(GFlops.@count_ops TD.q_vap_saturation($param_set, $ts))
+
+    summarize_flops(flops)
+end
+#! format: on


### PR DESCRIPTION
This PR adds a flops monitoring job, as some operations (`^` in particular) seem to be expensive in a GCM setting.