### PR TITLE
Reduce number of ^ calls

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Thermodynamics"
 uuid = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 authors = ["Climate Modeling Alliance"]
-version = "0.9.2"
+version = "0.9.3"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"


### PR DESCRIPTION
This PR
 - Adds a few methods that allow us to compute saturation vapor pressure ahead of time
 - Reduce the number of saturation vapor pressure calls using these new methods
 - a step towards #119