### PR TITLE
Add microbenchmarks for Float32 and Float64

### DIFF
--- a/perf/jet.jl
+++ b/perf/jet.jl
@@ -4,8 +4,9 @@ include("common_micro_bm.jl")
 # so we disable them here.
 TD.print_warning() = false
 
-function jet_thermo_states()
-    ArrayType = Array{Float64}
+function jet_thermo_states(::Type{FT}) where {FT}
+    param_set = get_parameter_set(FT)
+    ArrayType = Array{FT}
     profiles = TD.TestedProfiles.PhaseEquilProfiles(param_set, ArrayType)
 
     @testset "JET tests" begin
@@ -20,11 +21,11 @@ function jet_thermo_states()
             TD.PhaseEquil_ρpq,
         )
             for cond in conditions(C)
-                args = sample_args(profiles, cond, C)
+                args = sample_args(profiles, param_set, cond, C)
                 JET.@test_opt C(param_set, args...)
             end
         end
     end
 end
 
-jet_thermo_states()
+jet_thermo_states(Float32)

--- a/perf/microbenchmarks.jl
+++ b/perf/microbenchmarks.jl
@@ -1,8 +1,9 @@
 include("common_micro_bm.jl")
 
-function benchmark_thermo_states()
+function benchmark_thermo_states(::Type{FT}) where {FT}
     summary = OrderedCollections.OrderedDict()
-    ArrayType = Array{Float64}
+    ArrayType = Array{FT}
+    param_set = get_parameter_set(FT)
     profiles = TD.TestedProfiles.PhaseEquilProfiles(param_set, ArrayType)
 
     for C in (
@@ -16,13 +17,14 @@ function benchmark_thermo_states()
         TD.PhaseEquil_ρpq,
     )
         for cond in conditions(C)
-            args = sample_args(profiles, cond, C)
-            trial = BenchmarkTools.@benchmark $C(param_set, $args...)
+            args = sample_args(profiles, param_set, cond, C)
+            trial = BenchmarkTools.@benchmark $C($param_set, $args...)
             summary[Symbol(nameof(C), :_, cond)] = get_summary(trial)
         end
     end
-
+    @info "Microbenchmarks for $FT"
     tabulate_summary(summary)
 end
 
-benchmark_thermo_states()
+benchmark_thermo_states(Float64)
+benchmark_thermo_states(Float32)


### PR DESCRIPTION
This PR adds microbenchmarks for Float32. I'm hoping that this provides more information on the impact of #125. However, we won't know the true impact until we test in ClimaAtmos since performance seems to depend on the actual values used.