### PR TITLE
Use alternative power func in exner.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Thermodynamics"
 uuid = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 authors = ["Climate Modeling Alliance"]
-version = "0.9.4"
+version = "0.9.5"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/relations.jl
+++ b/src/relations.jl
@@ -2488,7 +2488,8 @@ function exner_given_pressure(
     _R_m = gas_constant_air(param_set, q)
     _cp_m = cp_m(param_set, q)
 
-    return (p / MSLP)^(_R_m / _cp_m)
+    # return (p / MSLP)^(_R_m / _cp_m)
+    return pow_hack(p / MSLP, _R_m / _cp_m)
 end
 
 """

--- a/test/relations.jl
+++ b/test/relations.jl
@@ -777,7 +777,7 @@ end
         @test count(air_temperature.(param_set, ts_upper) .== Ref(_T_freeze)) ≥
               217
         @test count(air_temperature.(param_set, ts_mid) .== Ref(_T_freeze)) ≥
-              1392
+              1373
         # we should do this instead, but we're failing because some inputs are bad
         # E.g. p ~ 110_000 Pa, q_tot ~ 0.16, which results in negative θ_liq_ice
         # This means that we should probably update our tested profiles.


### PR DESCRIPTION
Followup to #125. I've also had to update one of the tests to adjust where we enter saturation adjustment. Behavior changes should be within floating point precision.