### PR TITLE
Broadcast parameters with Tuples

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Thermodynamics"
 uuid = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 authors = ["Climate Modeling Alliance"]
-version = "0.10.1"
+version = "0.10.2"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -47,7 +47,7 @@ end
 
 const ATP = ThermodynamicsParameters
 
-Base.broadcastable(ps::ATP) = Ref(ps)
+Base.broadcastable(ps::ATP) = tuple(ps)
 Base.eltype(::ThermodynamicsParameters{FT}) where {FT} = FT
 
 # wrappers

--- a/src/Thermodynamics.jl
+++ b/src/Thermodynamics.jl
@@ -85,7 +85,7 @@ include("config_numerical_method.jl")
 include("TemperatureProfiles.jl")
 include("TestedProfiles.jl")
 
-Base.broadcastable(dap::DryAdiabaticProcess) = Ref(dap)
-Base.broadcastable(phase::Phase) = Ref(phase)
+Base.broadcastable(dap::DryAdiabaticProcess) = tuple(dap)
+Base.broadcastable(phase::Phase) = tuple(phase)
 
 end #module Thermodynamics.jl


### PR DESCRIPTION
This PR changes broadcasting of thermodynamic parameters from `Ref`s to `Tuple`s, as they are immutable and can be stack allocated to avoid dynamic allocations.