### PR TITLE
Dont assume that MSLP and theta ref pressure are the same

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Thermodynamics"
 uuid = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 authors = ["Climate Modeling Alliance"]
-version = "0.10.2"
+version = "0.11.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -21,6 +21,7 @@ param_set = TP.ThermodynamicsParameters{FT}(; param_pairs...);
 Base.@kwdef struct ThermodynamicsParameters{FT}
     T_0::FT
     MSLP::FT
+    p_ref_theta::FT
     cp_v::FT
     cp_l::FT
     cp_i::FT

--- a/src/isentropic.jl
+++ b/src/isentropic.jl
@@ -28,10 +28,10 @@ function air_pressure_given_θ(
     Φ::FT,
     ::DryAdiabaticProcess,
 ) where {FT <: AbstractFloat}
-    MSLP::FT = TP.MSLP(param_set)
+    p0::FT = TP.p_ref_theta(param_set)
     _R_d::FT = TP.R_d(param_set)
     _cp_d::FT = TP.cp_d(param_set)
-    return MSLP * (1 - Φ / (θ * _cp_d))^(_cp_d / _R_d)
+    return p0 * (1 - Φ / (θ * _cp_d))^(_cp_d / _R_d)
 end
 
 """
@@ -72,6 +72,6 @@ function air_temperature(
 ) where {FT <: AbstractFloat}
     _R_d::FT = TP.R_d(param_set)
     _cp_d::FT = TP.cp_d(param_set)
-    MSLP::FT = TP.MSLP(param_set)
-    return (p / MSLP)^(_R_d / _cp_d) * θ
+    p0::FT = TP.p_ref_theta(param_set)
+    return (p / p0)^(_R_d / _cp_d) * θ
 end

--- a/src/relations.jl
+++ b/src/relations.jl
@@ -2293,12 +2293,12 @@ function air_temperature_given_ρθq(
     q::PhasePartition{FT} = q_pt_0(FT),
 ) where {FT <: Real}
 
-    MSLP::FT = TP.MSLP(param_set)
+    p0::FT = TP.p_ref_theta(param_set)
     cvm = cv_m(param_set, q)
     cpm = cp_m(param_set, q)
     R_m = gas_constant_air(param_set, q)
     κ = 1 - cvm / cpm
-    T_u = (ρ * R_m * θ_liq_ice / MSLP)^(R_m / cvm) * θ_liq_ice
+    T_u = (ρ * R_m * θ_liq_ice / p0)^(R_m / cvm) * θ_liq_ice
     T_1 = latent_heat_liq_ice(param_set, q) / cvm
     T_2 = -κ / (2 * T_u) * (latent_heat_liq_ice(param_set, q) / cvm)^2
     return T_u + T_1 + T_2
@@ -2545,13 +2545,13 @@ function exner_given_pressure(
     p::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
 ) where {FT <: Real}
-    MSLP::FT = TP.MSLP(param_set)
+    p0::FT = TP.p_ref_theta(param_set)
     # gas constant and isobaric specific heat of moist air
     _R_m = gas_constant_air(param_set, q)
     _cp_m = cp_m(param_set, q)
 
-    # return (p / MSLP)^(_R_m / _cp_m)
-    return pow_hack(p / MSLP, _R_m / _cp_m)
+    # return (p / p0)^(_R_m / _cp_m)
+    return pow_hack(p / p0, _R_m / _cp_m)
 end
 
 """

--- a/test/TemperatureProfiles.jl
+++ b/test/TemperatureProfiles.jl
@@ -28,7 +28,7 @@ parameter_set(::Type{Float32}) = param_set_Float32
         param_set = parameter_set(FT)
         _grav = FT(TP.grav(param_set))
         _R_d = FT(TP.R_d(param_set))
-        _MSLP = FT(TP.MSLP(param_set))
+        _p_ref = FT(TP.MSLP(param_set))
 
         z = collect(range(FT(0), stop = FT(25e3), length = 100))
         n = 7
@@ -61,19 +61,19 @@ parameter_set(::Type{Float32}) = param_set_Float32
                 p = last.(args)
 
                 # Test that surface pressure is equal to the
-                # specified boundary condition (MSLP)
+                # specified boundary condition p_ref (by default set to MSLP)
                 mask_z_0 = z .≈ 0
-                @test all(p[mask_z_0] .≈ _MSLP)
+                @test all(p[mask_z_0] .≈ _p_ref)
 
-                function log_p_over_MSLP(_z)
+                function log_p_over_p_ref(_z)
                     _, _p = profile(param_set, _z)
-                    return log(_p / _MSLP)
+                    return log(_p / _p_ref)
                 end
-                ∇log_p_over_MSLP =
-                    _z -> ForwardDiff.derivative(log_p_over_MSLP, _z)
+                ∇log_p_over_p_ref =
+                    _z -> ForwardDiff.derivative(log_p_over_p_ref, _z)
                 # Uses density computed from pressure derivative
                 # and ideal gas law to reconstruct virtual temperature
-                T_virt_rec = -_grav ./ (_R_d .* ∇log_p_over_MSLP.(z))
+                T_virt_rec = -_grav ./ (_R_d .* ∇log_p_over_p_ref.(z))
                 @test all(T_virt_rec .≈ T_virt)
             end
         end


### PR DESCRIPTION
We were assuming that mean sea level pressure (MSLP) and the reference pressure used in potential temperature are the same. This is technically not a mistake. It is causing problems in ClimaAtmos where we were overwriting `MSLP=101325` value to be `100000` hPa for some of our cases but not for others.

I'm hoping that differentiating between the two would help us get rid of those [overwrites](https://github.com/CliMA/ClimaAtmos.jl/blob/d91fe26e69a964746fea7778d98ab8ab760ed598/src/parameters/create_parameters.jl#L133-L156)

I kept the `MSLP` in temperature profiles and in the `specific_entropy_` reference pressure. Lucky for us entropy is not used in ClimaAtmos, so it doesn't really matter.   