### PR TITLE
Change supersaturation definition

### DIFF
--- a/src/relations.jl
+++ b/src/relations.jl
@@ -1154,34 +1154,34 @@ end
  - `Liquid()`, `Ice()` - liquid or ice phase to dispatch over.
  - `ts` thermodynamic state
 
-Returns supersaturation (qv/qv_sat -1) over water or ice.
+Returns supersaturation (pv/pv_sat -1) over water or ice.
 """
 function supersaturation(
     param_set::APS,
     q::PhasePartition{FT},
     ρ::FT,
     T::FT,
-    ::Liquid,
+    phase::Phase,
 ) where {FT <: Real}
 
-    q_sat::FT = q_vap_saturation_generic(param_set, T, ρ, Liquid())
-    q_vap::FT = vapor_specific_humidity(q)
+    p_v_sat::FT = saturation_vapor_pressure(param_set, T, phase)
+    p_v::FT = vapor_specific_humidity(q) * (ρ * TP.R_v(param_set) * T)
 
-    return q_vap / q_sat - FT(1)
+    return p_v / p_v_sat - FT(1)
 end
 function supersaturation(
     param_set::APS,
     q::PhasePartition{FT},
     ρ::FT,
     T::FT,
-    ::Ice,
+    p_v_sat::FT,
 ) where {FT <: Real}
 
-    q_sat::FT = q_vap_saturation_generic(param_set, T, ρ, Ice())
-    q_vap::FT = vapor_specific_humidity(q)
+    p_v::FT = vapor_specific_humidity(q) * (ρ * TP.R_v(param_set) * T)
 
-    return q_vap / q_sat - FT(1)
+    return p_v / p_v_sat - FT(1)
 end
+
 supersaturation(param_set::APS, ts::ThermodynamicState, phase::Phase) =
     supersaturation(
         param_set,

--- a/src/relations.jl
+++ b/src/relations.jl
@@ -1164,10 +1164,9 @@ function supersaturation(
     phase::Phase,
 ) where {FT <: Real}
 
-    p_v_sat::FT = saturation_vapor_pressure(param_set, T, phase)
-    p_v::FT = vapor_specific_humidity(q) * (ρ * TP.R_v(param_set) * T)
+    p_v_sat = saturation_vapor_pressure(param_set, T, phase)
 
-    return p_v / p_v_sat - FT(1)
+    return supersaturation(param_set, q, ρ, T, p_v_sat)
 end
 function supersaturation(
     param_set::APS,

--- a/test/relations.jl
+++ b/test/relations.jl
@@ -278,6 +278,13 @@ end
         _T_triple,
         Liquid(),
     ) ≈ 0.998 * q_tot / ρ_v_triple / ρ - 1
+    @test supersaturation(
+        param_set,
+        PhasePartition(q_tot, 1e-3 * q_tot, 1e-3 * q_tot),
+        ρ,
+        _T_triple,
+        saturation_vapor_pressure(param_set, _T_triple, Liquid()),
+    ) ≈ 0.998 * q_tot / ρ_v_triple / ρ - 1
 
     @test supersaturation(
         param_set,
@@ -285,6 +292,13 @@ end
         ρ,
         _T_triple,
         Ice(),
+    ) ≈ 0.998 * q_tot / ρ_v_triple / ρ - 1
+    @test supersaturation(
+        param_set,
+        PhasePartition(q_tot, 1e-3 * q_tot, 1e-3 * q_tot),
+        ρ,
+        _T_triple,
+        saturation_vapor_pressure(param_set, _T_triple, Ice()),
     ) ≈ 0.998 * q_tot / ρ_v_triple / ρ - 1
 
     # energy functions and inverse (temperature)


### PR DESCRIPTION
It actually shouldn't change anything right now. But i still think it will simplify life for us in CloudMicrophysics. - `S` is typically defined as `p_vap / p_vap_sat` . Different papers provide different parameterizations for `p_vap_sat` and it would be good to test their impact on S and ice formation without having to go through recomputing it to `q_vap_sat` 