### PR TITLE
Move parameter constructor to a package extension, use name maps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,14 @@ DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RootSolvers = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
+# Required for backwards compatibility with Julia <1.9
+CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
+
+[weakdeps]
+CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
+
+[extensions]
+CreateParametersExt = "CLIMAParameters"
 
 [compat]
 DocStringExtensions = "0.8.1, 0.9"
@@ -15,3 +23,4 @@ KernelAbstractions = "0.7, 0.8, 0.9"
 Random = "1"
 RootSolvers = "0.4"
 julia = "1.6"
+CLIMAParameters = "0.8"

--- a/docs/src/Clausius_Clapeyron.jl
+++ b/docs/src/Clausius_Clapeyron.jl
@@ -4,23 +4,10 @@ import CLIMAParameters as CP
 using Thermodynamics.TestedProfiles
 import Thermodynamics.Parameters as TP
 
-function get_parameter_set(::Type{FT}) where {FT}
-    toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
-    aliases = string.(fieldnames(TP.ThermodynamicsParameters))
-    param_pairs = CP.get_parameter_values!(toml_dict, aliases, "Thermodynamics")
-    param_set = TP.ThermodynamicsParameters{FT}(; param_pairs...)
-    logfilepath = joinpath(@__DIR__, "logfilepath_$FT.toml")
-    CP.log_parameter_information(toml_dict, logfilepath)
-    return param_set
-end
-const param_set_Float64 = get_parameter_set(Float64)
-const param_set_Float32 = get_parameter_set(Float32)
-parameter_set(::Type{Float64}) = param_set_Float64
-parameter_set(::Type{Float32}) = param_set_Float32
 ArrayType = Array{Float64}
-
 FT = eltype(ArrayType)
-param_set = parameter_set(FT)
+
+param_set = TP.ThermodynamicsParameters(FT)
 profiles = TestedProfiles.PhaseEquilProfiles(param_set, ArrayType)
 (; T, p, e_int, ρ, θ_liq_ice, phase_type) = profiles
 (; q_tot, q_liq, q_ice, q_pt, RH, e_kin, e_pot) = profiles

--- a/docs/src/TemperatureProfiles.md
+++ b/docs/src/TemperatureProfiles.md
@@ -22,11 +22,8 @@ import Thermodynamics as TD
 import Plots
 import CLIMAParameters as CP
 import Thermodynamics.Parameters as TP
-FT = Float64;
-toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
-aliases = string.(fieldnames(TP.ThermodynamicsParameters))
-param_pairs = CP.get_parameter_values!(toml_dict, aliases, "Thermodynamics")
-param_set = TP.ThermodynamicsParameters{FT}(; param_pairs...)
+FT = Float64
+param_set = TP.ThermodynamicsParameters(FT)
 z = range(FT(0), stop = FT(2.5e4), length = 50);
 
 isothermal = TD.TemperatureProfiles.IsothermalProfile(param_set, FT);
@@ -49,11 +46,8 @@ import Thermodynamics as TD
 import Plots
 import CLIMAParameters as CP
 import Thermodynamics.Parameters as TP
-FT = Float64;
-toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
-aliases = string.(fieldnames(TP.ThermodynamicsParameters))
-param_pairs = CP.get_parameter_values!(toml_dict, aliases, "Thermodynamics")
-param_set = TP.ThermodynamicsParameters{FT}(; param_pairs...)
+FT = Float64
+param_set = TP.ThermodynamicsParameters(FT)
 z = range(FT(0), stop = FT(2.5e4), length = 50);
 
 decaying = TD.TemperatureProfiles.DecayingTemperatureProfile{FT}(param_set);
@@ -75,11 +69,8 @@ import Thermodynamics as TD
 import Plots
 import CLIMAParameters as CP
 import Thermodynamics.Parameters as TP
-FT = Float64;
-toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
-aliases = string.(fieldnames(TP.ThermodynamicsParameters))
-param_pairs = CP.get_parameter_values!(toml_dict, aliases, "Thermodynamics")
-param_set = TP.ThermodynamicsParameters{FT}(; param_pairs...)
+FT = Float64
+param_set = TP.ThermodynamicsParameters(FT)
 z = range(FT(0), stop = FT(2.5e4), length = 50);
 
 dry_adiabatic = TD.TemperatureProfiles.DryAdiabaticProfile{FT}(param_set);

--- a/docs/src/TestedProfiles.md
+++ b/docs/src/TestedProfiles.md
@@ -9,11 +9,8 @@ import Thermodynamics as TD
 import Plots
 import CLIMAParameters as CP
 import Thermodynamics.Parameters as TP
-FT = Float64;
-toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
-aliases = string.(fieldnames(TP.ThermodynamicsParameters))
-param_pairs = CP.get_parameter_values!(toml_dict, aliases, "Thermodynamics")
-param_set = TP.ThermodynamicsParameters{FT}(; param_pairs...)
+FT = Float64
+param_set = TP.ThermodynamicsParameters(FT)
 
 profiles = TD.TestedProfiles.PhaseDryProfiles(param_set, Array{FT});
 (;T, ρ, z) = profiles
@@ -31,11 +28,8 @@ import Thermodynamics as TD
 import Plots
 import CLIMAParameters as CP
 import Thermodynamics.Parameters as TP
-FT = Float64;
-toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
-aliases = string.(fieldnames(TP.ThermodynamicsParameters))
-param_pairs = CP.get_parameter_values!(toml_dict, aliases, "Thermodynamics")
-param_set = TP.ThermodynamicsParameters{FT}(; param_pairs...)
+FT = Float64
+param_set = TP.ThermodynamicsParameters(FT)
 
 profiles = TD.TestedProfiles.PhaseEquilProfiles(param_set, Array{FT});
 (;T, ρ, q_tot, z) = profiles

--- a/docs/src/saturation_adjustment.jl
+++ b/docs/src/saturation_adjustment.jl
@@ -1,17 +1,13 @@
-import RootSolvers
-const RS = RootSolvers
+import RootSolvers as RS
 import Plots
 
-FT = Float64;
 import Thermodynamics as TD
-const TP = TD.Parameters
+import Thermodynamics.Parameters as TP
 import CLIMAParameters as CP
 
-TD.print_warning() = false
-toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
-aliases = string.(fieldnames(TP.ThermodynamicsParameters))
-param_pairs = CP.get_parameter_values!(toml_dict, aliases, "Thermodynamics")
-const param_set = TP.ThermodynamicsParameters{FT}(; param_pairs...)
+FT = Float64
+
+const param_set = TP.ThermodynamicsParameters(FT)
 
 profiles = TD.TestedProfiles.PhaseEquilProfiles(param_set, Array{FT});
 (; ρ, q_tot) = profiles

--- a/ext/CreateParametersExt.jl
+++ b/ext/CreateParametersExt.jl
@@ -1,0 +1,42 @@
+module CreateParametersExt
+
+import Thermodynamics.Parameters.ThermodynamicsParameters
+import CLIMAParameters as CP
+
+ThermodynamicsParameters(::Type{FT}) where {FT <: AbstractFloat} =
+    ThermodynamicsParameters(CP.create_toml_dict(FT))
+
+function ThermodynamicsParameters(toml_dict::CP.AbstractTOMLDict)
+    name_map = (;
+        :temperature_min_at_reference => :T_min_ref,
+        :entropy_water_vapor => :entropy_water_vapor,
+        :entropy_dry_air => :entropy_dry_air,
+        :potential_temperature_reference_pressure => :p_ref_theta,
+        :entropy_reference_temperature => :entropy_reference_temperature,
+        :temperature_saturation_adjustment_max => :T_max,
+        :molar_mass_dry_air => :molmass_dryair,
+        :pow_icenuc => :pow_icenuc,
+        :temperature_triple_point => :T_triple,
+        :adiabatic_exponent_dry_air => :kappa_d,
+        :pressure_triple_point => :press_triple,
+        :thermodynamics_temperature_reference => :T_0,
+        :temperature_water_freeze => :T_freeze,
+        :isobaric_specific_heat_ice => :cp_i,
+        :latent_heat_sublimation_at_reference => :LH_s0,
+        :isobaric_specific_heat_vapor => :cp_v,
+        :molar_mass_water => :molmass_water,
+        :mean_sea_level_pressure => :MSLP,
+        :isobaric_specific_heat_liquid => :cp_l,
+        :latent_heat_vaporization_at_reference => :LH_v0,
+        :temperature_saturation_adjustment_min => :T_min,
+        :gas_constant => :gas_constant,
+        :temperature_mean_at_reference => :T_surf_ref,
+        :gravitational_acceleration => :grav,
+        :temperature_homogenous_nucleation => :T_icenuc,
+    )
+    parameters = CP.get_parameter_values(toml_dict, name_map, "Thermodynamics")
+    FT = CP.float_type(toml_dict)
+    return ThermodynamicsParameters{FT}(; parameters...)
+end
+
+end

--- a/gpuenv/Project.toml
+++ b/gpuenv/Project.toml
@@ -10,7 +10,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
-CLIMAParameters = "0.6, 0.7"
+CLIMAParameters = "0.8"
 CUDA = "3.5"
 CUDAKernels = "0.3, 0.4"
 KernelAbstractions = "0.7, 0.8"

--- a/perf/common.jl
+++ b/perf/common.jl
@@ -1,21 +1,15 @@
 using Test
-import Thermodynamics
-const TD = Thermodynamics
-const TP = TD.Parameters
 
 import UnPack
 import BenchmarkTools
+import RootSolvers as RS
 
-import RootSolvers
-const RS = RootSolvers
+import Thermodynamics as TD
+import Thermodynamics.Parameters as TP
+import CLIMAParameters as CP
 
-import CLIMAParameters
-const CP = CLIMAParameters
 const FT = Float64
-toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
-aliases = string.(fieldnames(TP.ThermodynamicsParameters))
-param_pairs = CP.get_parameter_values!(toml_dict, aliases, "Thermodynamics")
-const param_set = TP.ThermodynamicsParameters{FT}(; param_pairs...)
+const param_set = TP.ThermodynamicsParameters(FT)
 
 ArrayType = Array{FT}
 profiles = TD.TestedProfiles.PhaseEquilProfiles(param_set, ArrayType)

--- a/perf/common_micro_bm.jl
+++ b/perf/common_micro_bm.jl
@@ -1,26 +1,14 @@
-import Thermodynamics
 import StatsBase
 import PrettyTables
 import OrderedCollections
-const TD = Thermodynamics
-const TP = TD.Parameters
 using JET
 using Test
-
 import UnPack
 import BenchmarkTools
 
-import CLIMAParameters
-const CP = CLIMAParameters
-function get_parameter_set(::Type{FT}) where {FT}
-    toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
-    aliases = string.(fieldnames(TP.ThermodynamicsParameters))
-    param_pairs = CP.get_parameter_values!(toml_dict, aliases, "Thermodynamics")
-    param_set = TP.ThermodynamicsParameters{FT}(; param_pairs...)
-    # logfilepath = joinpath(@__DIR__, "logfilepath_$FT.toml")
-    # CP.log_parameter_information(toml_dict, logfilepath)
-    return param_set
-end
+import Thermodynamics as TD
+import Thermodynamics.Parameters as TP
+import CLIMAParameters as CP
 
 #####
 ##### Finding indexes in profiles satisfying certain conditions

--- a/perf/jet.jl
+++ b/perf/jet.jl
@@ -5,7 +5,7 @@ include("common_micro_bm.jl")
 TD.print_warning() = false
 
 function jet_thermo_states(::Type{FT}) where {FT}
-    param_set = get_parameter_set(FT)
+    param_set = TP.ThermodynamicsParameters(FT)
     ArrayType = Array{FT}
     profiles = TD.TestedProfiles.PhaseEquilProfiles(param_set, ArrayType)
 

--- a/perf/microbenchmarks.jl
+++ b/perf/microbenchmarks.jl
@@ -3,7 +3,7 @@ include("common_micro_bm.jl")
 function benchmark_thermo_states(::Type{FT}) where {FT}
     summary = OrderedCollections.OrderedDict()
     ArrayType = Array{FT}
-    param_set = get_parameter_set(FT)
+    param_set = TP.ThermodynamicsParameters(FT)
     profiles = TD.TestedProfiles.PhaseEquilProfiles(param_set, ArrayType)
 
     for C in (

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -11,11 +11,14 @@ Parameters for Thermodynamics.jl.
 ```
 import CLIMAParameters as CP
 import Thermodynamics.Parameters as TP
+
 FT = Float64;
-toml_dict = CP.create_toml_dict(FT; dict_type = "alias");
-aliases = string.(fieldnames(TP.ThermodynamicsParameters));
-param_pairs = CP.get_parameter_values!(toml_dict, aliases, "Thermodynamics");
-param_set = TP.ThermodynamicsParameters{FT}(; param_pairs...);
+param_set = TP.ThermodynamicsParameters(FT)
+
+# Alternatively:
+toml_dict = CP.create_toml_dict(FT)
+param_set = TP.ThermodynamicsParameters(toml_dict)
+
 ```
 """
 Base.@kwdef struct ThermodynamicsParameters{FT}

--- a/src/Thermodynamics.jl
+++ b/src/Thermodynamics.jl
@@ -15,10 +15,8 @@ parameters). For example, to compute the mole-mass ratio:
 ```julia
 import CLIMAParameters as CP
 import Thermodynamics.Parameters as TP
-toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
-aliases = string.(fieldnames(TP.ThermodynamicsParameters))
-param_pairs = CP.get_parameter_values!(toml_dict, aliases, "Thermodynamics")
-param_set = TP.ThermodynamicsParameters{FT}(; param_pairs...)
+FT = Float64
+param_set = TP.ThermodynamicsParameters(FT)
 _molmass_ratio = TP.molmass_ratio(param_set)
 ```
 
@@ -87,5 +85,10 @@ include("TestedProfiles.jl")
 
 Base.broadcastable(dap::DryAdiabaticProcess) = tuple(dap)
 Base.broadcastable(phase::Phase) = tuple(phase)
+
+# For backwards compatibility with package extensions
+if !isdefined(Base, :get_extension)
+    include(joinpath("..", "ext", "CreateParametersExt.jl"))
+end
 
 end #module Thermodynamics.jl

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -22,7 +22,7 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
 ArtifactWrappers = "0.2"
-CLIMAParameters = "0.6, 0.7"
+CLIMAParameters = "0.8"
 KernelAbstractions = "0.7, 0.8"
 RootSolvers = "0.4"
 UnPack = "1.0"

--- a/test/TemperatureProfiles.jl
+++ b/test/TemperatureProfiles.jl
@@ -1,31 +1,14 @@
 using Test
-import Thermodynamics
-const TD = Thermodynamics
-const TP = TD.Parameters
-const TDTP = TD.TemperatureProfiles
+import Thermodynamics as TD
+import Thermodynamics.Parameters as TP
+import Thermodynamics.TemperatureProfiles as TDTP
 using ForwardDiff
 
-import CLIMAParameters
-const CP = CLIMAParameters
-
-function get_parameter_set(::Type{FT}) where {FT}
-    toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
-    aliases = string.(fieldnames(TP.ThermodynamicsParameters))
-    param_pairs = CP.get_parameter_values!(toml_dict, aliases, "Thermodynamics")
-    param_set = TP.ThermodynamicsParameters{FT}(; param_pairs...)
-    logfilepath = joinpath(@__DIR__, "logfilepath_$FT.toml")
-    CP.log_parameter_information(toml_dict, logfilepath)
-    return param_set
-end
-
-const param_set_Float64 = get_parameter_set(Float64)
-const param_set_Float32 = get_parameter_set(Float32)
-parameter_set(::Type{Float64}) = param_set_Float64
-parameter_set(::Type{Float32}) = param_set_Float32
+import CLIMAParameters as CP
 
 @testset "TemperatureProfiles - DecayingTemperatureProfile" begin
     for FT in [Float32, Float64]
-        param_set = parameter_set(FT)
+        param_set = TP.ThermodynamicsParameters(FT)
         _grav = FT(TP.grav(param_set))
         _R_d = FT(TP.R_d(param_set))
         _p_ref = FT(TP.MSLP(param_set))

--- a/test/data_tests.jl
+++ b/test/data_tests.jl
@@ -16,7 +16,7 @@ dycoms_dataset_path = get_data_folder(dycoms_dataset)
 
 @testset "Data tests" begin
     FT = Float64
-    param_set = parameter_set(FT)
+    param_set = TP.ThermodynamicsParameters(FT)
     data = joinpath(dycoms_dataset_path, "test_data_PhaseEquil.nc")
     ds_PhaseEquil = Dataset(data, "r")
     e_int = Array{FT}(ds_PhaseEquil["e_int"][:])
@@ -28,7 +28,7 @@ dycoms_dataset_path = get_data_folder(dycoms_dataset)
 end
 
 @testset "pθq data-driven tests" begin
-    param_set = parameter_set(Float64)
+    param_set = TP.ThermodynamicsParameters(Float64)
     #! format: off
     pθq_broken = [
         # (; p = , θ_liq_ice = , q_tot = ),


### PR DESCRIPTION
This PR adds a package extension which includes new convenience constructors for `ThermodynamicsParameters` when CLIMAParameters is loaded.

The constructors are 
- `ThermodynamicsParameters(FT)`
- `ThermodynamicsParameters(toml_dict)`

The core changes are in `ext/CreateParametersExt.jl` and `Project.toml`, but I have updated the repo to work with the new parameter constructor.

This PR updates to the newest release of ClimaParameters and incorporates breaking changes.

This PR remove all instances of the `parameter_set` function and replaces it with the new constructors. 
I will also fix up the import statements if people like the core changes of this PR.
