### PR TITLE
Convert data-based test to sampling-based test

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-ArtifactWrappers = "a14bc488-3040-4b00-9dc1-f6467924858a"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
@@ -9,7 +8,6 @@ Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
@@ -21,7 +19,6 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
-ArtifactWrappers = "0.2"
 CLIMAParameters = "0.8"
 KernelAbstractions = "0.7, 0.8"
 RootSolvers = "0.4"

--- a/test/data_tests.jl
+++ b/test/data_tests.jl
@@ -1,30 +1,31 @@
-using Pkg.Artifacts
-
-using ArtifactWrappers
-
-# Get dycoms dataset folder:
-dycoms_dataset = ArtifactWrapper(
-    @__DIR__,
-    "dycoms",
-    ArtifactFile[ArtifactFile(
-        url = "https://caltech.box.com/shared/static/bxau6i46y6ikxn2sy9krgz0sw5vuptfo.nc",
-        filename = "test_data_PhaseEquil.nc",
-    ),],
+import Random
+function sample_range_dycoms(;
+    param_set,
+    e_int_range,
+    ρ_range,
+    q_tot_range,
+    n_samples,
 )
-dycoms_dataset_path = get_data_folder(dycoms_dataset)
-
+    for i in 1:n_samples
+        e_int = Random.rand(e_int_range)
+        ρ = Random.rand(ρ_range)
+        q_tot = Random.rand(q_tot_range)
+        ts = PhaseEquil_ρeq(param_set, ρ, e_int, q_tot, 4)
+        # ts = PhaseEquil_ρeq(param_set, ρ, e_int, q_tot, 3) # fails
+    end
+end
 
 @testset "Data tests" begin
     FT = Float64
     param_set = TP.ThermodynamicsParameters(FT)
-    data = joinpath(dycoms_dataset_path, "test_data_PhaseEquil.nc")
-    ds_PhaseEquil = Dataset(data, "r")
-    e_int = Array{FT}(ds_PhaseEquil["e_int"][:])
-    ρ = Array{FT}(ds_PhaseEquil["ρ"][:])
-    q_tot = Array{FT}(ds_PhaseEquil["q_tot"][:])
-
-    ts = PhaseEquil_ρeq.(Ref(param_set), ρ, e_int, q_tot, 4)
-    # ts = PhaseEquil_ρeq.(Ref(param_set), ρ, e_int, q_tot, 3) # Fails
+    Random.seed!(1234)
+    sample_range_dycoms(;
+        param_set,
+        e_int_range = (28311.801716:30981.514836),
+        ρ_range = (1.124755:1.129586),
+        q_tot_range = (0.011897:0.013305),
+        n_samples = 11_000,
+    )
 end
 
 @testset "pθq data-driven tests" begin

--- a/test/relations.jl
+++ b/test/relations.jl
@@ -1,7 +1,6 @@
 using Test
 
 using UnPack
-using NCDatasets
 using Random
 import RootSolvers as RS
 using LinearAlgebra

--- a/test/update_constructor_data.jl
+++ b/test/update_constructor_data.jl
@@ -6,7 +6,6 @@ allows us to optimize the convergence rate of the thermodynamics
 constructor for a variety of realistic input values.
 =#
 
-using NCDatasets
 using DelimitedFiles
 
 """


### PR DESCRIPTION
This PR removes the use of the collected dataset, and replaces it with a sampling-based test based on the range of the dataset. I can confirm that the new tests works for `maxiter = 4` and fails for `maxiter = 3`, which seems sufficient in terms of replacing the use of the dataset. This is nice because now we can remove ArtifactWrappers and NCDatasets from the test environment.