### PR TITLE
Update virtual_dry_static_energy

### DIFF
--- a/src/relations.jl
+++ b/src/relations.jl
@@ -2915,9 +2915,10 @@ function virtual_dry_static_energy(
     ts::ThermodynamicState{FT},
     e_pot::FT,
 ) where {FT <: Real}
+    T_0::FT = TP.T_0(param_set)
+    cp_d::FT = TP.cp_d(param_set)
     T_virt = virtual_temperature(param_set, ts)
-    _cp_m = cp_m(param_set, ts)
-    return _cp_m * T_virt + e_pot
+    return cp_d * (T_virt - T_0) + e_pot
 end
 
 """

--- a/test/relations.jl
+++ b/test/relations.jl
@@ -646,6 +646,8 @@ end
         @test all(has_condensate.(q_dry) .== false)
 
         e_tot = total_energy.(param_set, ts, e_kin, e_pot)
+        _cp_d = FT(TP.cp_d(param_set))
+        _T_0 = FT(TP.T_0(param_set))
         @test all(
             specific_enthalpy.(param_set, ts) .≈
             e_int .+
@@ -665,8 +667,7 @@ end
         )
         @test all(
             virtual_dry_static_energy.(param_set, ts, e_pot) .≈
-            cp_m.(param_set, ts) .* virtual_temperature.(param_set, ts) .+
-            e_pot,
+            _cp_d .* (virtual_temperature.(param_set, ts) .- _T_0) .+ e_pot,
         )
 
         # PhaseEquil


### PR DESCRIPTION
Includes the reference T_0 and uses cp_d instead of cp_m in the virtual dry static energy calculation. This shouldn't make much difference, but is more consistent with other equations.