### PR TITLE
Skip inlining PhaseEquil for equilibrium phases

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Thermodynamics"
 uuid = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 authors = ["Climate Modeling Alliance"]
-version = "0.11.5"
+version = "0.11.6"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/relations.jl
+++ b/src/relations.jl
@@ -1456,7 +1456,7 @@ end
     param_set::APS,
     ts::AbstractPhaseDry{FT},
 ) where {FT <: Real} = q_pt_0(FT)
-@inline function PhasePartition(param_set::APS, ts::AbstractPhaseEquil)
+function PhasePartition(param_set::APS, ts::AbstractPhaseEquil)
     T = air_temperature(param_set, ts)
     ρ = air_density(param_set, ts)
     q_tot = total_specific_humidity(param_set, ts)


### PR DESCRIPTION
I think that this is technically a ClimaCore issue (or an issue in Julia base) but, for some reason, inlining `PhasePartition(param_set::APS, ts::AbstractPhaseEquil)` results in runtime allocations. I have a reproducer, but it involves ClimaCore, so I'll open the issue there.