### PR TITLE
Fix zero `q_tot` edge case

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Thermodynamics"
 uuid = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 authors = ["Climate Modeling Alliance"]
-version = "0.11.6"
+version = "0.11.7"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/relations.jl
+++ b/src/relations.jl
@@ -1573,7 +1573,7 @@ See also [`saturation_adjustment`](@ref).
     tol = RS.RelativeSolutionTolerance(relative_temperature_tol)
 
     T_1 = max(_T_min, air_temperature(param_set, e_int, PhasePartition(q_tot))) # Assume all vapor
-    if T_1 > _T_min
+    if T_1 ≥ _T_min
         q_v_sat = q_vap_saturation(param_set, T_1, ρ, phase_type)
         unsaturated = q_tot <= q_v_sat
         if unsaturated
@@ -1717,7 +1717,7 @@ See also [`saturation_adjustment`](@ref).
     ρ_1 = ρ_T(T_1)
     q_v_sat = q_vap_saturation(param_set, T_1, ρ_1, phase_type)
     unsaturated = q_tot <= q_v_sat
-    if unsaturated && T_1 > _T_min
+    if unsaturated && T_1 ≥ _T_min
         return T_1
     end
     _T_freeze::FT = TP.T_freeze(param_set)
@@ -1825,7 +1825,7 @@ See also [`saturation_adjustment`](@ref).
     ρ_1 = ρ_T(T_1)
     q_v_sat = q_vap_saturation(param_set, T_1, ρ_1, phase_type)
     unsaturated = q_tot <= q_v_sat
-    if unsaturated && T_1 > _T_min
+    if unsaturated && T_1 ≥ _T_min
         return T_1
     end
     _T_freeze::FT = TP.T_freeze(param_set)
@@ -2048,7 +2048,7 @@ See also [`saturation_adjustment`](@ref).
     T_1 = max(_T_min, air_temp(PhasePartition(q_tot))) # Assume all vapor
     q_v_sat = q_vap_saturation(param_set, T_1, ρ, phase_type)
     unsaturated = q_tot <= q_v_sat
-    if unsaturated && T_1 > _T_min
+    if unsaturated && T_1 ≥ _T_min
         return T_1
     end
     T_2 = air_temp(PhasePartition(q_tot, FT(0), q_tot)) # Assume all ice
@@ -2153,7 +2153,7 @@ See also [`saturation_adjustment`](@ref).
     T_1 = max(T_min, air_temp(PhasePartition(q_tot))) # Assume all vapor
     q_v_sat_1 = q_vap_sat(T_1)
     unsaturated = q_tot <= q_v_sat_1
-    if unsaturated && T_1 > T_min
+    if unsaturated && T_1 ≥ T_min
         return T_1
     end
     temperature_tol = T_freeze * relative_temperature_tol


### PR DESCRIPTION
This PR fixes a zero `q_tot` edge case:

```julia
using Revise
import Thermodynamics as TD
using CLIMAParameters # load convenience constructors

thermo_params = TD.Parameters.ThermodynamicsParameters(Float32)

e_int=Float32(-3.687397e7);
ρ=Float32(0.0027615533);
q_tot=Float32(0.0);
maxiter=100
tol=Float32(0.003)
ts = TD.PhaseEquil_ρeq(
    thermo_params,
    ρ,
    e_int,
    q_tot,
    maxiter,
    eltype(thermo_params)(tol),
)
```
fails on main, and passes in this PR.

This was found in the log here: https://buildkite.com/clima/climaatmos-ci/builds/16548. This could be a fix for at least one job breaking in https://github.com/CliMA/ClimaAtmos.jl/issues/2635.

By the way, being able to create parameters in this way is just so nice! (cc @nefrathenrici)