### PR TITLE
Remove dispatch on FT for Dual number support

### DIFF
--- a/src/Thermodynamics.jl
+++ b/src/Thermodynamics.jl
@@ -70,7 +70,7 @@ const APS = TP.ThermodynamicsParameters
 # Allow users to skip printing warnings on non-convergence
 @inline print_warning() = true
 
-@inline q_pt_0(::Type{FT}) where {FT} = PhasePartition(FT(0), FT(0), FT(0))
+@inline q_pt_0(::APS{FT}) where {FT} = PhasePartition(FT(0), FT(0), FT(0))
 
 @inline solution_type() = RS.CompactSolution()
 include("DataCollection.jl")

--- a/test/relations.jl
+++ b/test/relations.jl
@@ -142,19 +142,19 @@ end
     @test gas_constant_air(param_set, PhasePartition(FT(1))) === _R_v
     @test gas_constant_air(param_set, PhasePartition(FT(0.5), FT(0.5))) ≈
           _R_d / 2
-    @test gas_constant_air(param_set, FT) == _R_d
+    @test gas_constant_air(param_set) == _R_d
 
     @test cp_m(param_set, PhasePartition(FT(0))) === _cp_d
     @test cp_m(param_set, PhasePartition(FT(1))) === _cp_v
     @test cp_m(param_set, PhasePartition(FT(1), FT(1))) === _cp_l
     @test cp_m(param_set, PhasePartition(FT(1), FT(0), FT(1))) === _cp_i
-    @test cp_m(param_set, FT) == _cp_d
+    @test cp_m(param_set) == _cp_d
 
     @test cv_m(param_set, PhasePartition(FT(0))) === _cp_d - _R_d
     @test cv_m(param_set, PhasePartition(FT(1))) === _cp_v - _R_v
     @test cv_m(param_set, PhasePartition(FT(1), FT(1))) === _cv_l
     @test cv_m(param_set, PhasePartition(FT(1), FT(0), FT(1))) === _cv_i
-    @test cv_m(param_set, FT) == _cv_d
+    @test cv_m(param_set) == _cv_d
 
     # speed of sound
     @test soundspeed_air(param_set, _T_0 + 20, PhasePartition(FT(0))) ==
@@ -643,7 +643,7 @@ end
             condensate.(q_pt) .==
             getproperty.(q_pt, :liq) .+ getproperty.(q_pt, :ice),
         )
-        @test all(has_condensate.(q_dry) .== false)
+        @test all(has_condensate.(param_set, q_dry) .== false)
 
         e_tot = total_energy.(param_set, ts, e_kin, e_pot)
         _cp_d = FT(TP.cp_d(param_set))


### PR DESCRIPTION
In order to enable automatic differentiation in `ClimaAtmos.jl`, we need to get rid of dispatch on `FT`. For example, consider the definition
```
@inline function moist_static_energy(
    param_set::APS,
    ts::ThermodynamicState{FT},
    e_pot::FT,
) where {FT <: Real}
    return specific_enthalpy(param_set, ts) + e_pot
end
```
This does not work when `ts` contains `Dual` numbers and `e_pot` is a regular `Float32` or `Float64`, which occurs when `ts` depends on the prognostic state while `e_pot` is a constant. In general, it is hard to anticipate which of the values that come from `ClimaAtmos.jl` will be `Dual` numbers, since the same value can be either prescribed or inferred from the prognostic state, depending on the model configuration. This is particularly significant for surface conditions, where the chain of computations can vary a lot between different surface parameterizations.

In order to make this change easier to review, I'll split it up into several PRs. This PR removes all dispatch on `FT` from `relations.jl`. In places where `FT` is necessary for type-stability (i.e., when we need to return `FT(0)` or `FT(1)` from a conditional statement) or for obtaining machine epsilon (`eps(FT)`), it is now inferred from the parameter set. As long as the parameter set does not contain any `Dual` numbers, this ensures that "constant" values will always be represented as `Float32`s or `Float64`s.