### PR TITLE
Add some additional fixes to support Dual numbers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Thermodynamics"
 uuid = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 authors = ["Climate Modeling Alliance"]
-version = "0.12.0"
+version = "0.12.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"


### PR DESCRIPTION
This is a followup to #199, with some additional fixes for supporting `Dual` numbers in `ClimaAtmos`. Specifically, this PR adds methods for converting a `ThermodynamicState{<:AbstractFloat}` to a `ThermodynamicState{<:Dual}`, and it removes the requirement that the solution tolerance of saturation adjustment must have the same type as the input quantities. It also fixes a typo in the `PhaseDry_ρT` constructor and bumps the minor version number.