### PR TITLE
Remove type restriction on e_pot

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Thermodynamics"
 uuid = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 authors = ["Climate Modeling Alliance"]
-version = "0.12.2"
+version = "0.12.3"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/relations.jl
+++ b/src/relations.jl
@@ -2941,9 +2941,9 @@ Moist static energy, given
 """
 @inline function moist_static_energy(
     param_set::APS,
-    ts::ThermodynamicState{FT},
-    e_pot::FT,
-) where {FT <: Real}
+    ts::ThermodynamicState,
+    e_pot,
+)
     return specific_enthalpy(param_set, ts) + e_pot
 end
 
@@ -2957,9 +2957,9 @@ Virtual dry static energy, given
 """
 @inline function virtual_dry_static_energy(
     param_set::APS,
-    ts::ThermodynamicState{FT},
-    e_pot::FT,
-) where {FT <: Real}
+    ts::ThermodynamicState,
+    e_pot,
+)
     T_0 = TP.T_0(param_set)
     cp_d = TP.cp_d(param_set)
     T_virt = virtual_temperature(param_set, ts)


### PR DESCRIPTION
Another followup to #200 and #201. When using `SurfaceFluxes` with `Dual` numbers, we need to compute the `virtual_dry_static_energy` of a thermodynamic state, where the state is specified using `Dual` numbers but its potential energy is specified as a regular `Float32`/`Float64`. This PR removes the restriction that the type of `e_pot` must match the `eltype` of the thermodynamic state for `virtual_dry_static_energy` and `moist_static_energy` (which follows the same pattern).