### PR TITLE
Add flop count perf job back in

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -58,12 +58,12 @@ steps:
       slurm_ntasks: 1
     timeout_in_minutes: 60
 
-  # - label: ":mag::rocket: Constructor flop measurements"
-  #   command:
-  #     - "julia --project=perf perf/flops.jl"
-  #   agents:
-  #     slurm_ntasks: 1
-  #   timeout_in_minutes: 60
+  - label: ":mag::rocket: Constructor flop measurements"
+    command:
+      - "julia --project=perf perf/flops.jl"
+    agents:
+      slurm_ntasks: 1
+    timeout_in_minutes: 60
 
   - label: ":mag::rocket: JET tests"
     command:

--- a/perf/Project.toml
+++ b/perf/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
+CountFlops = "1db9610d-79e1-487a-8d40-77f3295c7593"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"

--- a/perf/flops.jl
+++ b/perf/flops.jl
@@ -1,6 +1,6 @@
 include("common.jl")
 include("common_micro_bm.jl")
-import GFlops
+import CountFlops
 import OrderedCollections
 import PrettyTables
 
@@ -40,15 +40,15 @@ end
     flops = OrderedCollections.OrderedDict()
     ts = TD.PhaseEquil_ρeq(param_set, ρ[1], e_int[1], q_tot[1])
 
-    flops["PhasePartition"] = total_flops(GFlops.@count_ops TD.PhasePartition($param_set, $ts))
-    flops["liquid_fraction"] = total_flops(GFlops.@count_ops TD.liquid_fraction($param_set, $ts))
-    flops["q_vap_saturation"] = total_flops(GFlops.@count_ops TD.q_vap_saturation($param_set, $ts))
+    flops["PhasePartition"] = total_flops(CountFlops.@count_ops TD.PhasePartition($param_set, $ts))
+    flops["liquid_fraction"] = total_flops(CountFlops.@count_ops TD.liquid_fraction($param_set, $ts))
+    flops["q_vap_saturation"] = total_flops(CountFlops.@count_ops TD.q_vap_saturation($param_set, $ts))
     i = find_dry(profiles)
-    flops["PhaseDry_ρe"] = total_flops(GFlops.@count_ops TD.PhaseDry_ρe($param_set, $(ρ[i]), $(e_int[i])))
+    flops["PhaseDry_ρe"] = total_flops(CountFlops.@count_ops TD.PhaseDry_ρe($param_set, $(ρ[i]), $(e_int[i])))
     i = find_dry(profiles)
-    flops["PhaseEquil_ρeq_dry"] = total_flops(GFlops.@count_ops TD.PhaseEquil_ρeq($param_set, $(ρ[i]), $(e_int[i]), $(q_tot[i])))
+    flops["PhaseEquil_ρeq_dry"] = total_flops(CountFlops.@count_ops TD.PhaseEquil_ρeq($param_set, $(ρ[i]), $(e_int[i]), $(q_tot[i])))
     i = find_sat_adjust_index(profiles, param_set, TD.PhaseEquil_ρeq)
-    flops["PhaseEquil_ρeq_moist"] = total_flops(GFlops.@count_ops TD.PhaseEquil_ρeq($param_set, $(ρ[i]), $(e_int[i]), $(q_tot[i])))
+    flops["PhaseEquil_ρeq_moist"] = total_flops(CountFlops.@count_ops TD.PhaseEquil_ρeq($param_set, $(ρ[i]), $(e_int[i]), $(q_tot[i])))
 
     summarize_flops(flops)
 end


### PR DESCRIPTION
This PR adds the flop counting perf job back into CI.

I was a bit too impatient waiting for https://github.com/triscale-innov/GFlops.jl/issues/49 to be fixed. I tried messaging the author on slack, it's been months since the issue was opened, and users still can't update to Julia 1.10. So, I made [CountFlops.jl](https://github.com/charleskawczynski/CountFlops.jl).

I think @dennisYatunin developed his own version, too. We could combine / extend it.

I think this is a very useful tool for simple, pointwise functions, like Thermodynamics, CloudMicrophysics, and SurfaceFluxes.