### PR TITLE
add ClimaCoupler downstream experiment

### DIFF
--- a/.github/workflows/Downstream-ClimaCoupler.yml
+++ b/.github/workflows/Downstream-ClimaCoupler.yml
@@ -1,0 +1,40 @@
+# Runs a short (~300s) coupled AMIP simulation with the ClimaCoupler.jl package.
+# Note that the ClimaCoupler.jl test suite is also run in the "Downstream" workflow.
+name: Downstream-ClimaCoupler
+on:
+  push:
+    branches:
+      - main
+    tags: '*'
+  pull_request:
+
+# Needed to allow julia-actions/cache to delete old caches that it has created
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: downstream ClimaCoupler.jl
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1.10'
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: actions/checkout@v4
+        with:
+          repository: 'CliMA/ClimaCoupler.jl'
+          path: ClimaCoupler.jl
+      - run: |
+          julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ -e 'using Pkg; Pkg.instantiate()'
+          julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ -e 'using Pkg; Pkg.develop(; path = ".")'
+          julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ ClimaCoupler.jl/experiments/ClimaEarth/run_amip.jl --config_file ClimaCoupler.jl/config/ci_configs/target_amip_albedo_function.yml --job_id target_amip_albedo_function


### PR DESCRIPTION
Adds a short (~300s) downstream coupled AMIP experiment using ClimaCoupler.jl. See the discussion in https://github.com/CliMA/Thermodynamics.jl/pull/226 to see why we choose to include this run. 