### PR TITLE
Patch PhaseEquil_pTRH

### DIFF
--- a/src/states.jl
+++ b/src/states.jl
@@ -691,8 +691,7 @@ Constructs a [`PhaseEquil`](@ref) thermodynamic state from temperature.
     p::FT,
     T::FT,
     RH::FT,
-    phase::Phase # states.jl called before relations.jl, therefore ::Phase is not defined in this scope.
-
+    phase::Phase, # states.jl called before relations.jl, therefore ::Phase is not defined in this scope.
 ) where {FT <: Real}
     phase_type = PhaseEquil{FT}
     p_vap_sat = saturation_vapor_pressure(param_set, T, phase)
@@ -720,7 +719,7 @@ over liquid surface.
     param_set::APS,
     p::FT,
     T::FT,
-    RH::FT
+    RH::FT,
 ) where {FT <: Real}
     phase_type = PhaseEquil{FT}
     p_vap_sat = saturation_vapor_pressure(param_set, T, liquid)

--- a/src/states.jl
+++ b/src/states.jl
@@ -671,10 +671,6 @@ end
 PhaseEquil_pθq(param_set::APS, p, θ_liq_ice, q_tot, args...) =
     PhaseEquil_pθq(param_set, promote(p, θ_liq_ice, q_tot)..., args...)
 
-# TODO: Call these types into scope from relations.jl?
-abstract type Phase end
-struct Liquid <: Phase end
-struct Ice <: Phase end
 """
     PhaseEquil_pTRH(param_set, p, T, RH, phase)
 
@@ -691,7 +687,8 @@ Constructs a [`PhaseEquil`](@ref) thermodynamic state from temperature.
     p::FT,
     T::FT,
     RH::FT,
-    phase::Phase, # states.jl called before relations.jl, therefore ::Phase is not defined in this scope.
+    phase, # states.jl called before relations.jl, therefore ::Phase is not defined in this scope.
+    # ^ unsafe
 ) where {FT <: Real}
     phase_type = PhaseEquil{FT}
     p_vap_sat = saturation_vapor_pressure(param_set, T, phase)
@@ -722,7 +719,7 @@ over liquid surface.
     RH::FT,
 ) where {FT <: Real}
     phase_type = PhaseEquil{FT}
-    p_vap_sat = saturation_vapor_pressure(param_set, T, liquid)
+    p_vap_sat = saturation_vapor_pressure(param_set, T, Liquid())
     p_vap = RH * p_vap_sat
     mmr = TP.molmass_ratio(param_set)
     q_tot = p_vap * mmr / (p - (1 - mmr) * p_vap)

--- a/src/states.jl
+++ b/src/states.jl
@@ -698,8 +698,8 @@ Constructs a [`PhaseEquil`](@ref) thermodynamic state from temperature.
     e_int = internal_energy(param_set, T, q_pt)
     return PhaseEquil{FT}(ρ, p, e_int, q_tot_safe, T)
 end
-PhaseEquil_pTRH(param_set::APS, p, T, q_tot) =
-    PhaseEquil_pTRH(param_set, promote(p, T, q_tot)...)
+PhaseEquil_pTRH(param_set::APS, p, T, RH) =
+    PhaseEquil_pTRH(param_set, promote(p, T, RH)...)
 
 #####
 ##### Non-equilibrium states

--- a/test/relations.jl
+++ b/test/relations.jl
@@ -1440,7 +1440,7 @@ end
             param_set,
             air_pressure.(param_set, ts_eq),
             air_temperature.(param_set, ts_eq),
-            q_tot,
+            RH,
         )
     ts_ρp =
         PhaseEquil_ρpq.(

--- a/test/relations.jl
+++ b/test/relations.jl
@@ -509,6 +509,15 @@ end
     q_tot_expected = FT(0)
     @test q_tot_expected ≈ TD.total_specific_humidity(param_set, ts_pTRH)
 
+    # Sanity check for PhaseEquil_pTRH constructor
+    # No humidity
+    p = FT(1e5)
+    T = FT(300)
+    RH = FT(0)
+    ts_pTRH = TD.PhaseEquil_pTRH(param_set, p, T, RH, Liquid())
+    q_tot_expected = FT(0)
+    @test q_tot_expected ≈ TD.total_specific_humidity(param_set, ts_pTRH)
+
     # q at Saturation
     p = FT(1e5)
     T = FT(300)


### PR DESCRIPTION
Added general form for PhaseEquil_pTRH constructor, and made a note in the docstring of previous form of constructor that liquid phase is assumed.

Please note the temporary fix directly before the constructor definitions, where I define the necessary types. This is redundant to the definitions in relations.jl, but the definitions in relations.jl are not in scope when states.jl is called within Thermodynamics.jl. Any suggestions on how to resolve this are welcome.