### PR TITLE
Add promotion methods required for autodiff in ClimaAtmos

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Thermodynamics"
 uuid = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 authors = ["Climate Modeling Alliance"]
-version = "0.12.10"
+version = "0.12.11"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/relations.jl
+++ b/src/relations.jl
@@ -117,6 +117,8 @@ and, optionally,
 ) where {FT <: Real}
     return gas_constant_air(param_set, q) * ρ * T
 end
+@inline air_pressure(param_set, T, ρ, q) =
+    air_pressure(param_set, promote_phase_partition(T, ρ, q)...)
 
 """
     air_pressure(param_set::APS, ts::ThermodynamicState)
@@ -153,6 +155,8 @@ and, optionally,
 ) where {FT <: Real}
     return p / (gas_constant_air(param_set, q) * T)
 end
+@inline air_density(param_set, T, p, q) =
+    air_density(param_set, promote_phase_partition(T, p, q)...)
 
 """
     air_density(param_set::APS, ts::ThermodynamicState)
@@ -468,6 +472,8 @@ and, optionally,
     return cvm * (T - T_0) + (q.tot - q.liq - q.ice) * e_int_v0 -
            q.ice * e_int_i0 - (1 - q.tot) * R_d * T_0
 end
+@inline internal_energy(param_set, T, q) =
+    internal_energy(param_set, promote_phase_partition(T, q)...)
 
 """
     internal_energy(param_set::APS, ts::ThermodynamicState)
@@ -624,6 +630,8 @@ The internal energy per unit mass in thermodynamic equilibrium at saturation whe
 ) where {FT <: Real, phase_type <: ThermodynamicState}
     return internal_energy(param_set, T, q_pt, cvm)
 end
+@inline internal_energy_sat(param_set, T, ρ, q_tot, phase_type) =
+    internal_energy_sat(param_set, promote(T, ρ, q_tot)..., phase_type)
 
 """
     internal_energy_sat(param_set::APS, ts::ThermodynamicState)
@@ -1414,6 +1422,8 @@ end
     )
     return PhasePartition_equil(param_set, T, ρ, q_tot, p_vap_sat, λ)
 end
+@inline PhasePartition_equil(param_set, T, ρ, q_tot, phase_type) =
+    PhasePartition_equil(param_set, promote(T, ρ, q_tot)..., phase_type)
 
 @inline PhasePartition_equil(param_set::APS, ts::ThermodynamicState) =
     PhasePartition_equil(
@@ -1452,6 +1462,8 @@ The residual `q.tot - q.liq - q.ice` is the vapor specific humidity.
     q_ice = (1 - λ) * q_c
     return PhasePartition(q_tot, q_liq, q_ice)
 end
+@inline PhasePartition_equil_given_p(param_set, T, p, q_tot, phase_type) =
+    PhasePartition_equil_given_p(param_set, promote(T, p, q_tot)..., phase_type)
 
 @inline PhasePartition(
     param_set::APS,

--- a/src/states.jl
+++ b/src/states.jl
@@ -87,9 +87,13 @@ end
 Base.convert(::Type{PhasePartition{FT}}, q_pt::PhasePartition) where {FT} =
     PhasePartition(FT(q_pt.tot), FT(q_pt.liq), FT(q_pt.ice))
 
+function promote_phase_partition(x, q_pt::PhasePartition)
+    (x′, tot, liq, ice) = promote(x, q_pt.tot, q_pt.liq, q_pt.tot)
+    return (x′, PhasePartition(tot, liq, ice))
+end
 function promote_phase_partition(x1, x2, q_pt::PhasePartition)
-    (x1, x2, tot, liq, ice) = promote(x1, x2, q_pt.tot, q_pt.liq, q_pt.tot)
-    return (x1, x2, PhasePartition(tot, liq, ice))
+    (x1′, x2′, tot, liq, ice) = promote(x1, x2, q_pt.tot, q_pt.liq, q_pt.tot)
+    return (x1′, x2′, PhasePartition(tot, liq, ice))
 end
 
 const ITERTYPE = Union{Int, Nothing}


### PR DESCRIPTION
This PR adds the minimal set of promotion methods required to differentiate the current versions of `set_implicit_precomputed_quantities!` and `implicit_tendency!` in ClimaAtmos using forward-mode automatic differentiation, as tested in CliMA/ClimaAtmos.jl#2730. The minor version number is also bumped to 0.12.11.

This is yet another followup to #199, #200, #201, and #203. I would like to reiterate that every further addition to the implicit cache and tendency in ClimaAtmos (e.g., nonequilibrium moisture, surface fluxes, etc.) will require more promotion methods to be added if we want to use autodiff. These promotion methods nullify the original purpose of the `::FT` type checks throughout this package, as they allow arbitrary combinations of `Float32`s and `Float64`s to be promoted to `Float64`s. We should consider removing these checks altogether, as they are introducing unnecessary friction to implicit solver development in ClimaAtmos.