### PR TITLE
Add one more promotion method for autodiff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Thermodynamics"
 uuid = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 authors = ["Climate Modeling Alliance"]
-version = "0.12.11"
+version = "0.12.12"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/relations.jl
+++ b/src/relations.jl
@@ -997,6 +997,8 @@ end
     # saturation vapor pressure over possible mixture of liquid and ice
     return saturation_vapor_pressure(param_set, T, LH_0, Δcp)
 end
+saturation_vapor_pressure(param_set, T, LH_0, Δcp) =
+    saturation_vapor_pressure(param_set, promote(T, LH_0, Δcp)...)
 
 # we may be hitting a slow path:
 # https://stackoverflow.com/questions/14687665/very-slow-stdpow-for-bases-very-close-to-1

--- a/src/states.jl
+++ b/src/states.jl
@@ -87,11 +87,11 @@ Base.convert(::Type{PhasePartition{FT}}, q_pt::PhasePartition) where {FT} =
     PhasePartition(FT(q_pt.tot), FT(q_pt.liq), FT(q_pt.ice))
 
 function promote_phase_partition(x, q_pt::PhasePartition)
-    (x′, tot, liq, ice) = promote(x, q_pt.tot, q_pt.liq, q_pt.tot)
+    (x′, tot, liq, ice) = promote(x, q_pt.tot, q_pt.liq, q_pt.ice)
     return (x′, PhasePartition(tot, liq, ice))
 end
 function promote_phase_partition(x1, x2, q_pt::PhasePartition)
-    (x1′, x2′, tot, liq, ice) = promote(x1, x2, q_pt.tot, q_pt.liq, q_pt.tot)
+    (x1′, x2′, tot, liq, ice) = promote(x1, x2, q_pt.tot, q_pt.liq, q_pt.ice)
     return (x1′, x2′, PhasePartition(tot, liq, ice))
 end
 


### PR DESCRIPTION
A recent change to the ClimaAtmos implicit tendency for one-moment microphysics requires us to add a promotion method for `saturation_vapor_pressure` to support automatic differentiation. In addition, there was a bug in the `promote_phase_partition` function where I accidentally used `q_tot` instead of `q_ice`, which is fixed in this PR. The minor version number is also bumped to 0.12.12. This is a followup to #199, #200, #201, #203, and #247.