### PR TITLE
RH based state constructor

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -31,7 +31,6 @@ PhaseEquil
 PhaseEquil_ρeq
 PhaseEquil_ρTq
 PhaseEquil_pTq
-PhaseEquil_pTRH
 PhaseEquil_pθq
 PhaseEquil_peq
 PhaseEquil_phq
@@ -106,6 +105,7 @@ vapor_specific_humidity
 virtual_pottemp
 virtual_temperature
 specific_entropy
+q_vap_from_RH_liquid
 ```
 
 ## Internal methods

--- a/src/states.jl
+++ b/src/states.jl
@@ -14,7 +14,6 @@ export ThermodynamicState,
     PhaseEquil_ρeq,
     PhaseEquil_ρTq,
     PhaseEquil_pTq,
-    PhaseEquil_pTRH,
     PhaseEquil_peq,
     PhaseEquil_phq,
     PhaseEquil_ρθq,
@@ -674,36 +673,6 @@ Constructs a [`PhaseEquil`](@ref) thermodynamic state from:
 end
 PhaseEquil_pθq(param_set::APS, p, θ_liq_ice, q_tot, args...) =
     PhaseEquil_pθq(param_set, promote(p, θ_liq_ice, q_tot)..., args...)
-
-"""
-    PhaseEquil_pTRH(param_set, p, T, RH)
-
-Constructs a [`PhaseEquil`](@ref) thermodynamic state from temperature.
-
- - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
- - `p` pressure
- - `T` temperature
- - `RH` relative humidity
-"""
-@inline function PhaseEquil_pTRH(
-    param_set::APS,
-    p::FT,
-    T::FT,
-    RH::FT,
-) where {FT <: Real}
-    phase_type = PhaseEquil{FT}
-    p_vap_sat = saturation_vapor_pressure(param_set, T, Liquid())
-    p_vap = RH * p_vap_sat
-    mmr = TP.molmass_ratio(param_set)
-    q_tot = p_vap * mmr / (p - (1 - mmr) * p_vap)
-    q_tot_safe = clamp(q_tot, FT(0), FT(1))
-    q_pt = PhasePartition_equil_given_p(param_set, T, p, q_tot_safe, phase_type)
-    ρ = air_density(param_set, T, p, q_pt)
-    e_int = internal_energy(param_set, T, q_pt)
-    return PhaseEquil{FT}(ρ, p, e_int, q_tot_safe, T)
-end
-PhaseEquil_pTRH(param_set::APS, p, T, q_tot) =
-    PhaseEquil_pTRH(param_set, promote(p, T, q_tot)...)
 
 #####
 ##### Non-equilibrium states


### PR DESCRIPTION
Below are my fixes to the state constructor based on relative humidity:

- changed the name to `PhaseEquil_pTRH_unsat_liquid_only` and added asserts to highlight that it's only working if `T>0C` and `RH <=1`
- fixed a typo with `mollmass_ratio` (but double check my equations to be sure)
- fixed the value in test (it's different because of the above typo)
- removed this constructor from the tests that are based on atmospheric profiles because the `T>0C` and `RH<=1` are not met there.

Here are my notes:
![PXL_20250419_001856303](https://github.com/user-attachments/assets/6bb499e4-7281-487d-a442-1e8812c03105)
