### PR TITLE
Try fixing ci 1.7 - macOS-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version:
+        julia-version:
           - '1.7'
           - '1.8'
           - '1.9'
@@ -30,6 +30,12 @@ jobs:
           - windows-latest
         arch:
           - x64
+        exclude:
+          - github-runner: macos-latest # Apple Silicon
+            julia-version: '1.7'
+        include:
+          - github-runner: macos-13 # Intel
+            julia-version: '1.7'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
Per https://discourse.julialang.org/t/how-to-fix-github-actions-ci-failures-with-julia-1-6-or-1-7-on-macos-latest-and-macos-14/117019

Older versions of Julia (such as Julia 1.6 and 1.7) do not have native binaries for Apple Silicon macOS, which is what we are given when asked for `macos-latest`. There are a couple of solutions provided in that thread. It' trying one that looks the least complicated