### PR TITLE
gas_constant(q_tot, q_liq, q_ice)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Thermodynamics"
 uuid = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 authors = ["Climate Modeling Alliance"]
-version = "0.12.13"
+version = "0.12.14"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/relations.jl
+++ b/src/relations.jl
@@ -66,19 +66,25 @@ export q_vap_from_RH_liquid
 
 """
     gas_constant_air(param_set, [q::PhasePartition])
+    gas_constant_air(param_set, q_tot, q_liq, q_ice)
 
 The specific gas constant of moist air given
  - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `q` [`PhasePartition`](@ref). Without this argument, the results are for dry air.
+ - `q_tot`, `q_liq` `q_ice` - specific liquid water contents for total water, liquid water and ice
 """
+@inline function gas_constant_air(param_set::APS, q_tot, q_liq, q_ice)
+    R_d = TP.R_d(param_set)
+    R_v = TP.R_v(param_set)
+    q_vap = q_tot - q_liq - q_ice
+    return R_d * (1 - q_tot) + R_v * q_vap
+end
+
 @inline function gas_constant_air(
     param_set::APS,
     q::PhasePartition{FT},
 ) where {FT}
-    R_d = TP.R_d(param_set)
-    molmass_ratio = TP.molmass_ratio(param_set)
-    return R_d *
-           (1 + (molmass_ratio - 1) * q.tot - molmass_ratio * (q.liq + q.ice))
+    return gas_constant_air(param_set, q.tot, q.liq, q.ice)
 end
 
 @inline gas_constant_air(param_set::APS, ::Type{FT}) where {FT} =

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -17,6 +17,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 
 [compat]
+Aqua = "0.8.13"
 KernelAbstractions = "0.9"
 RootSolvers = "0.4"
 julia = "1.7"


### PR DESCRIPTION
This PR provides an option to compute gas constant of moist air without using PhasePartiton