### PR TITLE
set error_on_non_convergence to false

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,6 @@
 Thermodynamics.jl Release Notes
 ========================
 
-main
-----
-
 v1.xxx  (TODO: release once refactoring is done)
 --------
 
@@ -20,6 +17,16 @@ v1.xxx  (TODO: release once refactoring is done)
   - Added comprehensive tests and physical consistency validation for these functions
   PR [259](https://github.com/CliMA/Thermodynamics.jl/pull/259)
   PR [263](https://github.com/CliMA/Thermodynamics.jl/pull/263)
+
+main
+----
+
+v0.15.0
+--------
+- Remove `q_vap_saturation_from_density` and `condensate`. 
+  PR [284](https://github.com/CliMA/Thermodynamics.jl/pull/284)
+- Set error_on_non_covergence and print_warning to false by default. 
+  PR [283](https://github.com/CliMA/Thermodynamics.jl/pull/283)
 
 v0.14.2
 --------

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Thermodynamics"
 uuid = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 authors = ["Climate Modeling Alliance"]
-version = "0.14.2"
+version = "0.15.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/Thermodynamics.jl
+++ b/src/Thermodynamics.jl
@@ -55,19 +55,16 @@ const APS = TP.AbstractThermodynamicsParameters
 # For printing literal strings on the gpu
 include("printing.jl")
 
-# Allow users to skip error on non-convergence
+# Allow users to print warning and throw errors on non-convergence
 # by importing:
 # ```julia
 # import Thermodynamics
-# Thermodynamics.error_on_non_convergence() = false
+# Thermodynamics.error_on_non_convergence() = true
+# Thermodynamics.print_warning() = true
 # ```
-# Error on convergence must be the default
-# behavior because this can result in printing
-# very large logs resulting in CI to seemingly hang.
-@inline error_on_non_convergence() = true
-
-# Allow users to skip printing warnings on non-convergence
-@inline print_warning() = true
+# By default, we don't print warnings and don't throw errors on non-convergence.
+@inline error_on_non_convergence() = false
+@inline print_warning() = false
 
 # Default phase partition for dry air
 @inline q_pt_0(::Type{FT}) where {FT} = PhasePartition(FT(0), FT(0), FT(0))

--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -16,6 +16,9 @@ This file contains tests for error handling on failed convergence.
     tol = FT(1e-10)
     T_virt = T
 
+    TD.error_on_non_convergence() = true
+    TD.print_warning() = true
+
     @testset "Saturation Adjustment" begin
         @test_throws ErrorException TD.saturation_adjustment.(
             RS.NewtonsMethod,


### PR DESCRIPTION
I'm not sure if this will work though as in the code comments it says:

> Error on convergence must be the default behavior because this can result in printing very large logs resulting in CI to seemingly hang.

Maybe someone who had an SA error can try this branch?